### PR TITLE
Revert commit 891a181, fix exception when logging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,3 @@ venv*
 
 .coverage
 .tox/
-out
-cache
-*.log
-index.*

--- a/pysmi/compiler.py
+++ b/pysmi/compiler.py
@@ -282,7 +282,7 @@ class MibCompiler:
                 if mibname not in processed:
                     processed[mibname] = statusMissing
 
-        print(
+        debug.logger & debug.flagCompiler and debug.logger(
             f'MIBs analyzed {len(parsedMibs)}, MIBs failed {len(failedMibs)}')
 
         #

--- a/pysmi/reader/httpclient.py
+++ b/pysmi/reader/httpclient.py
@@ -8,7 +8,7 @@ import socket
 import sys
 import time
 
-from requests import session
+from requests import Session
 
 
 from pysmi.reader.base import AbstractReader
@@ -50,7 +50,7 @@ class HttpReader(AbstractReader):
         """
         self._url = url
      
-        self.session = session()
+        self.session = Session()
         
         self._user_agent = 'pysmi-{}; python-{}.{}.{}; {}'.format(
             pysmi_version, sys.version_info[0], sys.version_info[1],

--- a/pysmi/reader/httpclient.py
+++ b/pysmi/reader/httpclient.py
@@ -96,7 +96,7 @@ class HttpReader(AbstractReader):
                     mtime = time.time()
 
                 debug.logger & debug.flagReader and debug.logger(
-                    'fetching source MIB {}, mtime {}'.format(url, response.headers['Last-Modified']))
+                    'fetching source MIB {}, mtime {}'.format(url, mtime))
 
                 return MibInfo(path=url, file=mibfile, name=mibalias, mtime=mtime), response.content.decode('utf-8')
 

--- a/pysmi/reader/httpclient.py
+++ b/pysmi/reader/httpclient.py
@@ -79,7 +79,7 @@ class HttpReader(AbstractReader):
             debug.logger & debug.flagReader and debug.logger('trying to fetch MIB from %s' % url)
 
             try:
-                response = self.session.get(url,headers=headers)
+                response = self.session.get(url, headers=headers)
                 
             except Exception:
                 debug.logger & debug.flagReader and debug.logger(f'failed to fetch MIB from {url}: {sys.exc_info()[1]}')

--- a/pysmi/scripts/mibdump.py
+++ b/pysmi/scripts/mibdump.py
@@ -358,17 +358,12 @@ def start():
                             writeMibs=writeMibsFlag,
                             ignoreErrors=ignoreErrorsFlag)
         )
-        
-        safe = {}
-        for x in sorted(processed):
-            if processed[x] != 'failed':
-                safe[x]=processed[x]
-                
+
         if buildIndexFlag:
             mibCompiler.buildIndex(
-                safe,
+                processed,
                 dryRun=dryrunFlag,
-                ignoreErrors=True
+                ignoreErrors=ignoreErrorsFlag
             )
 
     except error.PySmiError:
@@ -377,21 +372,22 @@ def start():
 
     else:
         if verboseFlag:
-            sys.stdout.write('{}reated/updated MIBs: {}\r\n'.format(dryrunFlag and 'Would be c' or 'C', ', '.join(
+            sys.stderr.write('{}reated/updated MIBs: {}\r\n'.format(dryrunFlag and 'Would be c' or 'C', ', '.join(
                 ['{}{}'.format(x, x != processed[x].alias and ' (%s)' % processed[x].alias or '') for x in sorted(processed) if processed[x] == 'compiled'])))
 
-            sys.stdout.write('Pre-compiled MIBs {}borrowed: {}\r\n'.format(dryrunFlag and 'Would be ' or '', ', '.join(
+            sys.stderr.write('Pre-compiled MIBs {}borrowed: {}\r\n'.format(dryrunFlag and 'Would be ' or '', ', '.join(
                 [f'{x} ({processed[x].path})' for x in sorted(processed) if processed[x] == 'borrowed'])))
 
-            sys.stdout.write(
+            sys.stderr.write(
                 'Up to date MIBs: %s\r\n' % ', '.join(['%s' % x for x in sorted(processed) if processed[x] == 'untouched']))
-            sys.stderr.write("Missing source MIBs: %s\n" % "\n ".join(
+
+            sys.stderr.write('Missing source MIBs: %s\r\n' % ', '.join(
                 ['%s' % x for x in sorted(processed) if processed[x] == 'missing']))
 
             sys.stderr.write(
                 'Ignored MIBs: %s\r\n' % ', '.join(['%s' % x for x in sorted(processed) if processed[x] == 'unprocessed']))
 
-            sys.stderr.write("Failed MIBs: %s\n" % "\n ".join(
+            sys.stderr.write('Failed MIBs: %s\r\n' % ', '.join(
                 [f'{x} ({processed[x].error})' for x in sorted(processed) if processed[x] == 'failed']))
 
         exitCode = EX_OK


### PR DESCRIPTION
Revert commit 891a181, which introduced a `print` statement in place of logging in library code as well as hardcoding the `ignoreErrorsFlag`.

Fix a KeyError that occurs when the "reader" debug flag is set and the `response` object's headers did not contain the `Last-Modified` header.

Replace call to deprecated `session` function with instantiation of `Session` class.