### PR TITLE
fix hex string log issue

### DIFF
--- a/pysmi/lexer/smi.py
+++ b/pysmi/lexer/smi.py
@@ -250,7 +250,7 @@ class SmiV2Lexer(AbstractLexer):
             value = value[1:]
         # TODO: raise in strict mode
         #    if len(value) % 2:
-        raise error.PySmiLexerError(f"Number of symbols have to be even in hex string {t.value}", lineno=t.lineno)
+        #    raise error.PySmiLexerError(f"Number of symbols have to be even in hex string {t.value}", lineno=t.lineno)
         return t
 
     def t_QUOTED_STRING(self, t):


### PR DESCRIPTION
This line was uncommented in earlier commit:
https://github.com/lextudio/pysmi/commit/ee23c156cc707b9729550702090747b956eb0d89#diff-af233ed940967984b19191a7cd04bd9d01ebb4efb926052816556417877e0d5d

It is producing following log and failing in file conversion Number of symbols have to be even in hex string 

Example log:
Failed MIBs: XYZ-MIB-NAME (Number of symbols have to be even in hex string '00000000'H at XYZ-MIB-NAME, line 123)