### PR TITLE
Various fixes and improvements regarding support of real-world MIBs

### DIFF
--- a/pysmi/codegen/base.py
+++ b/pysmi/codegen/base.py
@@ -277,6 +277,13 @@ class AbstractCodeGen:
         "RFC-1215": {"TRAP-TYPE": [("SNMPv2-SMI", "TRAP-TYPE")]},
     }
 
+    smiv1IdxTypes = ["INTEGER", "OCTET STRING", "IpAddress", "NetworkAddress"]
+
+    # Name prefix and starting number of fake index object types, as generated
+    # the fly to support SMIv1-only index types (e.g., "INDEX { INTEGER }").
+    fakeIdxPrefix = "pysmiFakeCol"
+    fakeIdxNumber = 1
+
     def genCode(self, ast, symbolTable, **kwargs):
         raise NotImplementedError()
 

--- a/pysmi/codegen/base.py
+++ b/pysmi/codegen/base.py
@@ -227,7 +227,7 @@ class AbstractCodeGen:
         "RFC1065-SMI": commonSyms["RFC1155-SMI/RFC1065-SMI"],
         "RFC1155-SMI": commonSyms["RFC1155-SMI/RFC1065-SMI"],
         "RFC1158-MIB": updateDict(
-            dict(commonSyms["RFC1155-SMI/RFC1065-SMI"]),
+            dict(commonSyms["RFC1158-MIB/RFC1213-MIB"]),
             (
                 ("nullSpecific", [("SNMPv2-SMI", "zeroDotZero")]),
                 ("ipRoutingTable", [("RFC1213-MIB", "ipRouteTable")]),

--- a/pysmi/codegen/base.py
+++ b/pysmi/codegen/base.py
@@ -5,7 +5,12 @@
 # License: https://www.pysnmp.com/pysmi/license.html
 #
 import sys
+from keyword import iskeyword
 from pysmi import error
+
+# Prefix added to symbols that happen to be Python keywords. The leading
+# underscore ensures that there is no overlap with any other symbols.
+RESERVED_KEYWORDS_PREFIX = "_pysmi_"
 
 
 def dorepr(s):
@@ -300,3 +305,9 @@ class AbstractCodeGen:
                 raise error.PySmiSemanticError("empty hex string to int conversion")
         else:
             return int(s)
+
+    @staticmethod
+    def transOpers(symbol):
+        if iskeyword(symbol):
+            symbol = RESERVED_KEYWORDS_PREFIX + symbol
+        return symbol.replace("-", "_")

--- a/pysmi/codegen/intermediate.py
+++ b/pysmi/codegen/intermediate.py
@@ -478,11 +478,13 @@ class IntermediateCodeGen(AbstractCodeGen):
 
         if syntax[0]:
             nodetype = syntax[0] == "Bits" and "scalar" or syntax[0]  # Bits hack
-            nodetype = (
+            # If this object type is used as a column, but it also has a
+            # "SEQUENCE OF" syntax, then it is really a table and not a column.
+            isColumn = (
                 pysmiName in self.symbolTable[self.moduleName[0]]["_symtable_cols"]
-                and "column"
-                or nodetype
+                and syntax[1]
             )
+            nodetype = isColumn and "column" or nodetype
             outDict["nodetype"] = nodetype
 
         outDict["class"] = "objecttype"

--- a/pysmi/codegen/intermediate.py
+++ b/pysmi/codegen/intermediate.py
@@ -21,8 +21,6 @@ if sys.version_info[0] > 2:
     unicode = str
     long = int
 
-RESERVED_KEYWORDS_PREFIX = "pysmi_"
-
 
 class IntermediateCodeGen(AbstractCodeGen):
     """Turns MIB AST into an intermediate representation.
@@ -89,10 +87,6 @@ class IntermediateCodeGen(AbstractCodeGen):
         self.moduleName = ["DUMMY"]
         self.genRules = {"text": True}
         self.symbolTable = {}
-
-    @staticmethod
-    def transOpers(symbol):
-        return symbol.replace("-", "_")
 
     def prepData(self, pdata):
         data = []
@@ -1043,16 +1037,10 @@ class IntermediateCodeGen(AbstractCodeGen):
                 self.handlersTable[declr[0]](self, self.prepData(declr[1:]))
 
         for sym in self.symbolTable[self.moduleName[0]]["_symtable_order"]:
-            true_sym = sym
-
-            if sym.startswith(RESERVED_KEYWORDS_PREFIX):
-                # Removing prefix added for reserved keywords
-                true_sym = sym[len(RESERVED_KEYWORDS_PREFIX) :]
-
-            if true_sym not in self._out:
+            if sym not in self._out:
                 raise error.PySmiCodegenError(f"No generated code for symbol {sym}")
 
-            outDict[sym] = self._out[true_sym]
+            outDict[sym] = self._out[sym]
 
         outDict["meta"] = OrderedDict()
         outDict["meta"]["module"] = self.moduleName[0]

--- a/pysmi/codegen/intermediate.py
+++ b/pysmi/codegen/intermediate.py
@@ -150,10 +150,6 @@ class IntermediateCodeGen(AbstractCodeGen):
 
         return OrderedDict(imports=outDict), tuple(sorted(imports))
 
-    # noinspection PyMethodMayBeStatic
-    def genLabel(self, symbol):
-        return "-" in symbol and symbol or ""
-
     def addToExports(self, symbol, moduleIdentity=0):
         self._seenSyms.add(symbol)
 
@@ -253,8 +249,7 @@ class IntermediateCodeGen(AbstractCodeGen):
     def genAgentCapabilities(self, data):
         name, productRelease, status, description, reference, oid = data
 
-        label = self.genLabel(name)
-        name = self.transOpers(name)
+        pysmiName = self.transOpers(name)
 
         oidStr, parentOid = oid
 
@@ -275,7 +270,7 @@ class IntermediateCodeGen(AbstractCodeGen):
         if self.genRules["text"] and reference:
             outDict["reference"] = reference
 
-        self.regSym(name, outDict, parentOid)
+        self.regSym(pysmiName, outDict, parentOid)
 
         return outDict
 
@@ -283,8 +278,7 @@ class IntermediateCodeGen(AbstractCodeGen):
     def genModuleIdentity(self, data):
         name, lastUpdated, organization, contactInfo, description, revisions, oid = data
 
-        label = self.genLabel(name)
-        name = self.transOpers(name)
+        pysmiName = self.transOpers(name)
 
         oidStr, parentOid = oid
 
@@ -308,7 +302,7 @@ class IntermediateCodeGen(AbstractCodeGen):
             if description:
                 outDict["description"] = description
 
-        self.regSym(name, outDict, parentOid, moduleIdentity=True)
+        self.regSym(pysmiName, outDict, parentOid, moduleIdentity=True)
 
         return outDict
 
@@ -316,8 +310,7 @@ class IntermediateCodeGen(AbstractCodeGen):
     def genModuleCompliance(self, data):
         name, status, description, reference, compliances, oid = data
 
-        label = self.genLabel(name)
-        name = self.transOpers(name)
+        pysmiName = self.transOpers(name)
 
         oidStr, parentOid = oid
 
@@ -338,7 +331,7 @@ class IntermediateCodeGen(AbstractCodeGen):
         if self.genRules["text"] and reference:
             outDict["reference"] = reference
 
-        self.regSym(name, outDict, parentOid, moduleCompliance=True)
+        self.regSym(pysmiName, outDict, parentOid, moduleCompliance=True)
 
         return outDict
 
@@ -346,8 +339,7 @@ class IntermediateCodeGen(AbstractCodeGen):
     def genNotificationGroup(self, data):
         name, objects, status, description, reference, oid = data
 
-        label = self.genLabel(name)
-        name = self.transOpers(name)
+        pysmiName = self.transOpers(name)
 
         oidStr, parentOid = oid
         outDict = OrderedDict()
@@ -373,7 +365,7 @@ class IntermediateCodeGen(AbstractCodeGen):
         if self.genRules["text"] and reference:
             outDict["reference"] = reference
 
-        self.regSym(name, outDict, parentOid)
+        self.regSym(pysmiName, outDict, parentOid)
 
         return outDict
 
@@ -381,8 +373,7 @@ class IntermediateCodeGen(AbstractCodeGen):
     def genNotificationType(self, data):
         name, objects, status, description, reference, oid = data
 
-        label = self.genLabel(name)
-        name = self.transOpers(name)
+        pysmiName = self.transOpers(name)
 
         oidStr, parentOid = oid
         outDict = OrderedDict()
@@ -408,7 +399,7 @@ class IntermediateCodeGen(AbstractCodeGen):
         if self.genRules["text"] and reference:
             outDict["reference"] = reference
 
-        self.regSym(name, outDict, parentOid)
+        self.regSym(pysmiName, outDict, parentOid)
 
         return outDict
 
@@ -416,8 +407,7 @@ class IntermediateCodeGen(AbstractCodeGen):
     def genObjectGroup(self, data):
         name, objects, status, description, reference, oid = data
 
-        label = self.genLabel(name)
-        name = self.transOpers(name)
+        pysmiName = self.transOpers(name)
 
         oidStr, parentOid = oid
         outDict = OrderedDict({"name": name, "oid": oidStr, "class": "objectgroup"})
@@ -440,7 +430,7 @@ class IntermediateCodeGen(AbstractCodeGen):
         if self.genRules["text"] and reference:
             outDict["reference"] = reference
 
-        self.regSym(name, outDict, parentOid)
+        self.regSym(pysmiName, outDict, parentOid)
 
         return outDict
 
@@ -448,8 +438,7 @@ class IntermediateCodeGen(AbstractCodeGen):
     def genObjectIdentity(self, data):
         name, status, description, reference, oid = data
 
-        label = self.genLabel(name)
-        name = self.transOpers(name)
+        pysmiName = self.transOpers(name)
 
         oidStr, parentOid = oid
 
@@ -467,7 +456,7 @@ class IntermediateCodeGen(AbstractCodeGen):
         if self.genRules["text"] and reference:
             outDict["reference"] = reference
 
-        self.regSym(name, outDict, parentOid)
+        self.regSym(pysmiName, outDict, parentOid)
 
         return outDict
 
@@ -487,13 +476,12 @@ class IntermediateCodeGen(AbstractCodeGen):
             oid,
         ) = data
 
-        label = self.genLabel(name)
-        name = self.transOpers(name)
+        pysmiName = self.transOpers(name)
 
         oidStr, parentOid = oid
         indexStr, fakeStrlist, fakeSyms = index or ("", "", [])
 
-        defval = self.genDefVal(defval, objname=name)
+        defval = self.genDefVal(defval, objname=pysmiName)
 
         outDict = OrderedDict()
         outDict["name"] = name
@@ -502,7 +490,7 @@ class IntermediateCodeGen(AbstractCodeGen):
         if syntax[0]:
             nodetype = syntax[0] == "Bits" and "scalar" or syntax[0]  # Bits hack
             nodetype = (
-                name in self.symbolTable[self.moduleName[0]]["_symtable_cols"]
+                pysmiName in self.symbolTable[self.moduleName[0]]["_symtable_cols"]
                 and "column"
                 or nodetype
             )
@@ -534,7 +522,7 @@ class IntermediateCodeGen(AbstractCodeGen):
         if self.genRules["text"] and description:
             outDict["description"] = description
 
-        self.regSym(name, outDict, parentOid)
+        self.regSym(pysmiName, outDict, parentOid)
         # TODO
         #        if fakeSyms:  # fake symbols for INDEX to support SMIv1
         #            for i in range(len(fakeSyms)):
@@ -547,8 +535,7 @@ class IntermediateCodeGen(AbstractCodeGen):
     def genTrapType(self, data):
         name, enterprise, variables, description, reference, value = data
 
-        label = self.genLabel(name)
-        name = self.transOpers(name)
+        pysmiName = self.transOpers(name)
 
         enterpriseStr, parentOid = enterprise
 
@@ -572,7 +559,7 @@ class IntermediateCodeGen(AbstractCodeGen):
         if self.genRules["text"] and reference:
             outDict["reference"] = reference
 
-        self.regSym(name, outDict, parentOid)
+        self.regSym(pysmiName, outDict, parentOid)
 
         return outDict
 
@@ -587,9 +574,9 @@ class IntermediateCodeGen(AbstractCodeGen):
         if declaration:
             parentType, attrs = declaration
             if parentType:  # skipping SEQUENCE case
-                name = self.transOpers(name)
+                pysmiName = self.transOpers(name)
                 outDict.update(attrs)
-                self.regSym(name, outDict)
+                self.regSym(pysmiName, outDict)
 
         return outDict
 
@@ -597,8 +584,7 @@ class IntermediateCodeGen(AbstractCodeGen):
     def genValueDeclaration(self, data):
         name, oid = data
 
-        label = self.genLabel(name)
-        name = self.transOpers(name)
+        pysmiName = self.transOpers(name)
 
         oidStr, parentOid = oid
         outDict = OrderedDict()
@@ -606,7 +592,7 @@ class IntermediateCodeGen(AbstractCodeGen):
         outDict["oid"] = oidStr
         outDict["class"] = "objectidentity"
 
-        self.regSym(name, outDict, parentOid)
+        self.regSym(pysmiName, outDict, parentOid)
 
         return outDict
 

--- a/pysmi/codegen/intermediate.py
+++ b/pysmi/codegen/intermediate.py
@@ -701,7 +701,7 @@ class IntermediateCodeGen(AbstractCodeGen):
                 outDict.update(value=hexval, format="hex")
 
         # quoted string
-        elif defval[0] == defval[-1] and defval[0] == '"':
+        elif defval and defval[0] == defval[-1] and defval[0] == '"':
             # common bug in MIBs
             if defval[1:-1] == "" and defvalType != "OctetString":
                 # a warning should be here

--- a/pysmi/codegen/intermediate.py
+++ b/pysmi/codegen/intermediate.py
@@ -1040,7 +1040,7 @@ class IntermediateCodeGen(AbstractCodeGen):
         self._complianceOids = []
         self.moduleName[0], moduleOid, imports, declarations = ast
 
-        outDict, importedModules = self.genImports(imports and imports or {})
+        outDict, importedModules = self.genImports(imports)
 
         for declr in declarations or []:
             if declr:

--- a/pysmi/codegen/intermediate.py
+++ b/pysmi/codegen/intermediate.py
@@ -762,8 +762,6 @@ class IntermediateCodeGen(AbstractCodeGen):
 
                 outDict.update(value=self.genBits([defvalBits])[1], format="bits")
 
-                return outDict
-
             else:
                 raise error.PySmiSemanticError(
                     f'unknown type "{defvalType}" for defval "{defval}" of symbol "{objname}"'

--- a/pysmi/codegen/intermediate.py
+++ b/pysmi/codegen/intermediate.py
@@ -137,7 +137,7 @@ class IntermediateCodeGen(AbstractCodeGen):
         outDict["class"] = "imports"
         for module in sorted(imports):
             symbols = []
-            for symbol in set(imports[module]):
+            for symbol in sorted(set(imports[module])):
                 symbols.append(symbol)
 
             if symbols:

--- a/pysmi/codegen/jfilters.py
+++ b/pysmi/codegen/jfilters.py
@@ -5,6 +5,8 @@
 # License: https://www.pysnmp.com/pysmi/license.html
 #
 
+from pysmi.codegen.base import AbstractCodeGen
+
 
 def capfirst(text):
     if not text:
@@ -19,3 +21,7 @@ def bitstring(bits):
     # The left-most character of the returned string is for bit number zero,
     # so reverse the bits, while also stripping off the "0b" prefix.
     return bin(mask)[:1:-1]
+
+
+def pythonsym(symbol):
+    return AbstractCodeGen.transOpers(symbol)

--- a/pysmi/codegen/jfilters.py
+++ b/pysmi/codegen/jfilters.py
@@ -11,3 +11,11 @@ def capfirst(text):
         return text
 
     return text[0].upper() + text[1:]
+
+
+def bitstring(bits):
+    mask = sum(1 << bit for bit in bits)
+
+    # The left-most character of the returned string is for bit number zero,
+    # so reverse the bits, while also stripping off the "0b" prefix.
+    return bin(mask)[:1:-1]

--- a/pysmi/codegen/jfilters.py
+++ b/pysmi/codegen/jfilters.py
@@ -25,3 +25,10 @@ def bitstring(bits):
 
 def pythonsym(symbol):
     return AbstractCodeGen.transOpers(symbol)
+
+
+def pythonstr(text):
+    if "\n" in text or "\r" in text:
+        return '"""\\\n' + text.replace("\\", "\\\\") + '"""'
+    else:
+        return '"' + text.replace("\\", "\\\\") + '"'

--- a/pysmi/codegen/pysnmp.py
+++ b/pysmi/codegen/pysnmp.py
@@ -148,6 +148,7 @@ class PySnmpCodeGen(IntermediateCodeGen):
         env.filters["capfirst"] = jfilters.capfirst
         env.filters["bitstring"] = jfilters.bitstring
         env.filters["pythonsym"] = jfilters.pythonsym
+        env.filters["pythonstr"] = jfilters.pythonstr
 
         try:
             tmpl = env.get_template(dstTemplate or self.TEMPLATE_NAME)

--- a/pysmi/codegen/pysnmp.py
+++ b/pysmi/codegen/pysnmp.py
@@ -146,6 +146,7 @@ class PySnmpCodeGen(IntermediateCodeGen):
         )
 
         env.filters["capfirst"] = jfilters.capfirst
+        env.filters["bitstring"] = jfilters.bitstring
 
         try:
             tmpl = env.get_template(dstTemplate or self.TEMPLATE_NAME)

--- a/pysmi/codegen/pysnmp.py
+++ b/pysmi/codegen/pysnmp.py
@@ -147,6 +147,7 @@ class PySnmpCodeGen(IntermediateCodeGen):
 
         env.filters["capfirst"] = jfilters.capfirst
         env.filters["bitstring"] = jfilters.bitstring
+        env.filters["pythonsym"] = jfilters.pythonsym
 
         try:
             tmpl = env.get_template(dstTemplate or self.TEMPLATE_NAME)

--- a/pysmi/codegen/symtable.py
+++ b/pysmi/codegen/symtable.py
@@ -433,7 +433,7 @@ class SymtableCodeGen(AbstractCodeGen):
         elif isinstance(defval, list):  # bits list
             val = defval
 
-        elif defval[0] == defval[-1] and defval[0] == '"':  # quoted strimg
+        elif defval and defval[0] == defval[-1] and defval[0] == '"':  # quoted string
             val = dorepr(defval[1:-1])
 
         else:  # symbol (oid as defval) or name for enumeration member

--- a/pysmi/codegen/symtable.py
+++ b/pysmi/codegen/symtable.py
@@ -78,11 +78,6 @@ class SymtableCodeGen(AbstractCodeGen):
         "snmpEnableAuthTraps": "snmpEnableAuthenTraps",  # RFC1158-MIB -> SNMPv2-MIB
     }
 
-    smiv1IdxTypes = ["INTEGER", "OCTET STRING", "IPADDRESS", "NETWORKADDRESS"]
-    ifTextStr = "if mibBuilder.loadTexts: "
-    indent = " " * 4
-    fakeidx = 1000  # starting index for fake symbols
-
     def __init__(self):
         self._rows = set()
         self._cols = {}  # k, v = name, datatype
@@ -458,7 +453,6 @@ class SymtableCodeGen(AbstractCodeGen):
     def genIndex(self, data, classmode=False):
         indexes = data[0]
 
-        fakeIdxName = "pysmiFakeCol"
         fakeIndexes, fakeSymsSyntax = [], []
 
         for idx in indexes:
@@ -469,11 +463,11 @@ class SymtableCodeGen(AbstractCodeGen):
                 objType = self.typeClasses.get(idxType, idxType)
                 objType = self.transOpers(objType)
 
-                fakeIndexes.append(self.fakeidx)
+                fakeIndexes.append(self.fakeIdxNumber)
                 fakeSymsSyntax.append((("MibTableColumn", ""), objType))
-                self.fakeidx += 1
+                self.fakeIdxNumber += 1
 
-        return fakeIdxName, fakeIndexes, fakeSymsSyntax
+        return self.fakeIdxPrefix, fakeIndexes, fakeSymsSyntax
 
     # noinspection PyUnusedLocal,PyUnusedLocal,PyMethodMayBeStatic
     def genIntegerSubType(self, data, classmode=False):

--- a/pysmi/codegen/symtable.py
+++ b/pysmi/codegen/symtable.py
@@ -7,7 +7,6 @@
 # Build an internally used symbol table for each passed MIB.
 #
 import sys
-from keyword import iskeyword
 from pysmi.mibinfo import MibInfo
 from pysmi.codegen.base import AbstractCodeGen, dorepr
 from pysmi import config, error
@@ -102,13 +101,6 @@ class SymtableCodeGen(AbstractCodeGen):
             return self.symsTable[symbol]
 
         return (symbol,)
-
-    @staticmethod
-    def transOpers(symbol):
-        if iskeyword(symbol):
-            symbol = "pysmi_" + symbol
-
-        return symbol.replace("-", "_")
 
     def prepData(self, pdata, classmode=False):
         data = []

--- a/pysmi/codegen/symtable.py
+++ b/pysmi/codegen/symtable.py
@@ -646,7 +646,7 @@ class SymtableCodeGen(AbstractCodeGen):
         self._out = {}  # should be new object, do not use `clear` method
         self.moduleName[0], moduleOid, imports, declarations = ast
 
-        out, importedModules = self.genImports(imports or {})
+        out, importedModules = self.genImports(imports)
 
         for declr in declarations or []:
             if declr:

--- a/pysmi/codegen/templates/pysnmp/managed-objects-instances.j2
+++ b/pysmi/codegen/templates/pysnmp/managed-objects-instances.j2
@@ -23,15 +23,15 @@ MibScalarInstance, = mibBuilder.importSymbols(
    if definition['class'] == 'objecttype' and
       definition['nodetype'] in ('scalar', 'column') %}
     {% if loop.first and loop.last %}
-({{ symbol|replace('-', '_') }},) = mibBuilder.importSymbols(
+({{ symbol|pythonsym }},) = mibBuilder.importSymbols(
     "{{ mib['meta']['module'] }}",
     {% elif loop.first %}
-({{ symbol|replace('-', '_') }},
+({{ symbol|pythonsym }},
     {% elif loop.last %}
- {{ symbol|replace('-', '_') }}) = mibBuilder.importSymbols(
+ {{ symbol|pythonsym }}) = mibBuilder.importSymbols(
     "{{ mib['meta']['module'] }}",
     {%  else %}
- {{ symbol|replace('-', '_') }},
+ {{ symbol|pythonsym }},
     {%  endif %}
 {% endfor %}
 {% for symbol, definition in mib.items()|sort
@@ -51,28 +51,28 @@ MibScalarInstance, = mibBuilder.importSymbols(
 {% for symbol, definition in mib.items() %}
     {% if definition['nodetype'] == 'scalar' %}
         {% block mib_scalar_object_instance_definition scoped %}
-{{ symbol|replace('-', '_')|capfirst }}_ObjectInstance = MibScalarInstance
+{{ symbol|capfirst }}_ObjectInstance = MibScalarInstance
         {% endblock %}
         {% block mib_scalar_object_instantiation scoped %}
 # TODO: uncomment Managed Object Instance instantiation optionally
 #       setting a default value (via `.syntax.clone()`)
-# _{{ symbol|replace('-', '_') }} = {{ symbol|replace('-', '_')|capfirst }}_ObjectInstance(
-#      {{ symbol|replace('-', '_') }}.name,
+# _{{ symbol }} = {{ symbol|capfirst }}_ObjectInstance(
+#      {{ symbol }}.name,
 #      (0,),
-#      {{ symbol|replace('-', '_') }}.syntax
+#      {{ symbol }}.syntax
 # )
         {% endblock %}
     {% elif definition['nodetype'] == 'column' %}
         {% block mib_table_column_object_instance_definition scoped %}
-{{ symbol|replace('-', '_')|capfirst }}_ObjectInstance = MibScalarInstance
+{{ symbol|capfirst }}_ObjectInstance = MibScalarInstance
         {% endblock %}
         {% block mib_column_instantiation scoped %}
 # TODO: Set proper OID for Managed Object Instance (see INDEX clause in MIB)
 # TODO: Initialize Managed Object Instance value (via `.syntax.clone()`)
-# _{{ symbol|replace('-', '_') }} = {{ symbol|replace('-', '_')|capfirst }}_ObjectInstance(
-#     {{ symbol|replace('-', '_') }}.name,
+# _{{ symbol }} = {{ symbol|capfirst }}_ObjectInstance(
+#     {{ symbol }}.name,
 #     (<add columnar indices here>,),
-#     {{ symbol|replace('-', '_') }}.syntax
+#     {{ symbol }}.syntax
 # )
         {% endblock %}
     {% endif %}
@@ -92,13 +92,13 @@ mibBuilder.exportSymbols(
        if definition['class'] == 'objecttype' and
            definition['nodetype'] in ('scalar', 'column') %}
         {% if loop.first and loop.last %}
-    # **{"{{ symbol }}": _{{ symbol|replace('-', '_') }}}
+    # **{"{{ definition['name'] }}": _{{ symbol }}}
         {% elif loop.first %}
-    # **{"{{ symbol }}": _{{ symbol|replace('-', '_') }},
+    # **{"{{ definition['name'] }}": _{{ symbol }},
         {% elif loop.last %}
-    # "{{ symbol }}": _{{ symbol|replace('-', '_') }}}
+    # "{{ definition['name'] }}": _{{ symbol }}}
         {% else %}
-    # "{{ symbol }}": _{{ symbol|replace('-', '_') }},
+    # "{{ definition['name'] }}": _{{ symbol }},
         {% endif %}
     {%  endfor %}
 )

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -39,17 +39,18 @@ Managed Objects Instances.
 # Import SMI symbols from the MIBs this MIB depends on
 
 {% for module, symbols in mib['imports'].items() %}
+    {# Unlike elsewhere, the symbol names are not 'Pythonized' here. #}
     {% for symbol in symbols %}
         {% if loop.first and loop.last %}
-({{ symbol|replace('-', '_') }},) = mibBuilder.importSymbols(
+({{ symbol|pythonsym }},) = mibBuilder.importSymbols(
     "{{ module }}",
         {% elif loop.first %}
-({{ symbol|replace('-', '_') }},
+({{ symbol|pythonsym }},
         {% elif loop.last %}
- {{ symbol|replace('-', '_') }}) = mibBuilder.importSymbols(
+ {{ symbol|pythonsym }}) = mibBuilder.importSymbols(
     "{{ module }}",
         {%  else %}
- {{ symbol|replace('-', '_') }},
+ {{ symbol|pythonsym }},
         {%  endif %}
     {%  endfor %}
     {% for symbol in symbols %}

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -327,13 +327,6 @@ _{{ symbol|replace('-', '_')|capfirst }}_Object = MibTableRow
             {% endfor %}
 )
         {% endif %}
-        {% if 'augmention' in definition %}
-{{ definition['augmention']['object'] }}.registerAugmentions(
-    ("{{ mib['meta']['module'] }}",
-     "{{ symbol|replace('-', '_') }}")
-)
-{{ symbol|replace('-', '_') }}.setIndexNames(*{{ definition['augmention']['object'] }}.getIndexNames())
-        {% endif %}
     {% elif definition['nodetype'] == 'column' %}
         {% block mib_table_column_object_definition scoped %}
 _{{ symbol|replace('-', '_')|capfirst }}_Object = MibTableColumn
@@ -366,6 +359,16 @@ if mibBuilder.loadTexts:
 {{ definition['description']|wordwrap }}
 """)
     {% endif %}
+{% endfor %}
+{% for symbol, definition in mib.items()
+   if definition['class'] == 'objecttype'
+   and definition['nodetype'] == 'row'
+   and 'augmention' in definition %}
+{{ definition['augmention']['object'] }}.registerAugmentions(
+    ("{{ mib['meta']['module'] }}",
+     "{{ symbol|replace('-', '_') }}")
+)
+{{ symbol|replace('-', '_') }}.setIndexNames(*{{ definition['augmention']['object'] }}.getIndexNames())
 {% endfor %}
 {% endblock -%}
 

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -215,7 +215,7 @@ class {{ symbol }}({{ definition['type']['type'] }}):
 {% for symbol, definition in mib.items() if definition['class'] == 'textualconvention' %}
 
 
-class {{ symbol }}(TextualConvention, {{ definition['type']['type'] }}):
+class {{ symbol }}({{ definition['type']['type'] }}, TextualConvention):
     status = "{{ definition.get('status', 'current') }}"
     {% if 'displayhint' in definition %}
     displayHint = "{{ definition['displayhint'] }}"

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -76,36 +76,30 @@ Managed Objects Instances.
 {{ symbol }}.setRevisions(
         {% for revision in definition.get('revisions', ()) %}
             {% if loop.first and loop.last %}
-        ("{{ revision['revision'] }}",)
+        ({{ revision['revision']|pythonstr }},)
             {% elif loop.first %}
-        ("{{ revision['revision'] }}",
+        ({{ revision['revision']|pythonstr }},
             {% elif loop.last %}
-         "{{ revision['revision'] }}")
+         {{ revision['revision']|pythonstr }})
             {%  else %}
-         "{{ revision['revision'] }}",
+         {{ revision['revision']|pythonstr }},
             {%  endif %}
         {%  endfor %}
 )
     {% endif %}
     {% if 'lastupdated' in definition %}
-{{ symbol }}.setLastUpdated("{{ definition['lastupdated'] }}")
+{{ symbol }}.setLastUpdated({{ definition['lastupdated']|pythonstr }})
     {% endif %}
     {% if 'organization' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol }}.setOrganization("""\
-{{ definition['organization']|wordwrap }}
-""")
+    {{ symbol }}.setOrganization({{ definition['organization']|pythonstr }})
     {% endif %}
     {% if 'contactinfo' in definition %}
-{{ symbol }}.setContactInfo("""\
-{{ definition['contactinfo']|wordwrap }}
-""")
+{{ symbol }}.setContactInfo({{ definition['contactinfo']|pythonstr }})
     {% endif %}
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol }}.setDescription("""\
-{{ definition['description']|wordwrap }}
-""")
+    {{ symbol }}.setDescription({{ definition['description']|pythonstr }})
     {% endif %}
 
 {% endfor %}
@@ -176,7 +170,7 @@ if mibBuilder.loadTexts:
         {% endif %}
     {% elif definition['default']['default']['format'] == 'string' %}
     {# TODO: pyasn1 does not like defaulted strings #}
-    defaultValue = OctetString("{{ definition['default']['default']['value'] }}")
+    defaultValue = OctetString({{ definition['default']['default']['value']|pythonstr }})
     {% elif definition['default']['default']['format'] == 'oid' %}
     defaultValue = {{ definition['default']['default']['value'] }}
     {% elif definition['default']['default']['format'] == 'enum'
@@ -219,22 +213,18 @@ class {{ symbol }}({{ definition['type']['type'] }}):
 class {{ symbol }}({{ definition['type']['type'] }}, TextualConvention):
     status = "{{ definition.get('status', 'current') }}"
     {% if 'displayhint' in definition %}
-    displayHint = "{{ definition['displayhint'] }}"
+    displayHint = {{ definition['displayhint']|pythonstr }}
     {% endif %}
     {% if 'constraints' in definition['type'] %}
 {{ constraints(definition['type']['type'], definition['type']['constraints']) }}
     {% endif %}
     {% if 'description' in definition %}
     if mibBuilder.loadTexts:
-        description = """\
-{{ definition['description']|wordwrap }}
-"""
+        description = {{ definition['description']|pythonstr }}
     {% endif %}
     {% if 'reference' in definition %}
     if mibBuilder.loadTexts:
-        reference = """\
-{{ definition['reference']|wordwrap }}
-"""
+        reference = {{ definition['reference']|pythonstr }}
     {% endif %}
 {% endfor %}
 
@@ -346,19 +336,15 @@ if mibBuilder.loadTexts:
     {% endif %}
     {% if 'units' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol }}.setUnits("{{ definition['units'] }}")
+    {{ symbol }}.setUnits({{ definition['units']|pythonstr }})
     {% endif %}
     {% if 'reference' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol }}.setReference("""\
-{{ definition['reference']|wordwrap }}
-""")
+    {{ symbol }}.setReference({{ definition['reference']|pythonstr }})
     {% endif %}
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol }}.setDescription("""\
-{{ definition['description']|wordwrap }}
-""")
+    {{ symbol }}.setDescription({{ definition['description']|pythonstr }})
     {% endif %}
 {% endfor %}
 {% for symbol, definition in mib.items()
@@ -401,9 +387,7 @@ if mibBuilder.loadTexts:
     {{ symbol }}.setStatus("{{ definition['status'] }}")
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol }}.setDescription("""\
-{{ definition['description']|wordwrap }}
-""")
+    {{ symbol }}.setDescription({{ definition['description']|pythonstr }})
     {% endif %}
 
 {% endfor %}
@@ -439,9 +423,7 @@ if mibBuilder.loadTexts:
     )
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol }}.setDescription("""\
-{{ definition['description']|wordwrap }}
-""")
+    {{ symbol }}.setDescription({{ definition['description']|pythonstr }})
     {% endif %}
 
 {% endfor %}
@@ -477,9 +459,7 @@ if mibBuilder.loadTexts:
     )
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol }}.setDescription("""\
-{{ definition['description']|wordwrap }}
-""")
+    {{ symbol }}.setDescription({{ definition['description']|pythonstr }})
     {% endif %}
 
 {% endfor %}
@@ -496,15 +476,11 @@ if mibBuilder.loadTexts:
 )
     {% if 'productrelease' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol }}.setProductRelease(
-        "{{ definition['productrelease'] }}"
-    )
+    {{ symbol }}.setProductRelease({{ definition['productrelease']|pythonstr }})
     {% endif %}
     {% if 'reference' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol }}.setReference(
-        "{{ definition['reference'] }}"
-    )
+    {{ symbol }}.setReference({{ definition['reference']|pythonstr }})
     {% endif %}
 if mibBuilder.loadTexts:
     {{ symbol }}.setStatus(
@@ -512,9 +488,7 @@ if mibBuilder.loadTexts:
     )
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol }}.setDescription("""\
-{{ definition['description']|wordwrap }}
-""")
+    {{ symbol }}.setDescription({{ definition['description']|pythonstr }})
     {% endif %}
 
 {% endfor %}
@@ -550,9 +524,7 @@ if mibBuilder.loadTexts:
     )
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol }}.setDescription("""\
-{{ definition['description']|wordwrap }}
-""")
+    {{ symbol }}.setDescription({{ definition['description']|pythonstr }})
     {% endif %}
 
 {% endfor %}

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -177,8 +177,7 @@ if mibBuilder.loadTexts:
     {# TODO: pyasn1 does not like defaulted strings #}
     defaultValue = OctetString("{{ definition['default']['default']['value'] }}")
     {% elif definition['default']['default']['format'] == 'oid' %}
-    {# TODO: this OID might be in a string form #}
-    defaultValue = "{{ definition['default']['default']['value'] }}"
+    defaultValue = {{ definition['default']['default']['value'] }}
     {% elif definition['default']['default']['format'] == 'enum'
         and 'constraints' in definition['syntax'] %}
     {# TODO: pyasn1 does not like default enum #}

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -230,6 +230,12 @@ class {{ symbol }}(TextualConvention, {{ definition['type']['type'] }}):
 {{ definition['description']|wordwrap }}
 """
     {% endif %}
+    {% if 'reference' in definition %}
+    if mibBuilder.loadTexts:
+        reference = """\
+{{ definition['reference']|wordwrap }}
+"""
+    {% endif %}
 {% endfor %}
 
 {% endblock -%}

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -185,7 +185,7 @@ if mibBuilder.loadTexts:
     defaultValue = {{ definition['syntax']['constraints']['enumeration'][definition['default']['default']['value']] }}
     {% elif definition['default']['default']['format'] == 'bits' %}
     {# TODO: pyasn1 does not like default named bits #}
-    defaultValue = {{ definition['syntax']['constraints']['enumeration'][definition['default']['default']['value']] }}
+    defaultBinValue = "{{ definition['default']['default']['value']['bits'].values()|bitstring }}"
     {%  endif %}
 {% endmacro -%}
 

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -102,7 +102,7 @@ if mibBuilder.loadTexts:
     {% endif %}
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setDescription("""\
+    {{ symbol }}.setDescription("""\
 {{ definition['description']|wordwrap }}
 """)
     {% endif %}
@@ -250,7 +250,7 @@ class {{ symbol }}(TextualConvention, {{ definition['type']['type'] }}):
             {% if 'default' in definition or 'constraints' in definition['syntax'] or 'bits' in definition['syntax'] %}
 
 
-class _{{ symbol|replace('-', '_')|capfirst }}_Type({{ definition['syntax']['type'] }}):
+class _{{ symbol|capfirst }}_Type({{ definition['syntax']['type'] }}):
     """Custom type {{ symbol }} based on {{ definition['syntax']['type'] }}"""
                 {% if 'default' in definition %}
 {{ default(definition) }}
@@ -275,53 +275,53 @@ class _{{ symbol|replace('-', '_')|capfirst }}_Type({{ definition['syntax']['typ
                 {% endif %}
 
                 {% if 'constraints' in definition['syntax'] or 'bits' in definition['syntax'] %}
-_{{ symbol|replace('-', '_')|capfirst }}_Type.__name__ = "{{ definition['syntax']['type'] }}"
+_{{ symbol|capfirst }}_Type.__name__ = "{{ definition['syntax']['type'] }}"
                 {% endif %}
             {% else %}
-_{{ symbol|replace('-', '_')|capfirst }}_Type = {{ definition['syntax']['type'] }}
+_{{ symbol|capfirst }}_Type = {{ definition['syntax']['type'] }}
             {% endif %}
         {% endblock %}
     {% endif %}
     {% if definition['class'] == 'objectidentity' %}
         {% block mib_scalar_object_identity_definition scoped %}
-_{{ symbol|replace('-', '_')|capfirst }}_ObjectIdentity = ObjectIdentity
+_{{ symbol|capfirst }}_ObjectIdentity = ObjectIdentity
         {% endblock %}
         {% block mib_object_identity_instantiation scoped %}
-{{ symbol|replace('-', '_') }} = _{{ symbol|replace('-', '_')|capfirst }}_ObjectIdentity(
+{{ symbol }} = _{{ symbol|capfirst }}_ObjectIdentity(
     {{ definition['oid'] }}
 )
         {% endblock %}
     {% elif definition['nodetype'] == 'scalar' %}
         {% block mib_scalar_object_definition scoped %}
-_{{ symbol|replace('-', '_')|capfirst }}_Object = MibScalar
+_{{ symbol|capfirst }}_Object = MibScalar
         {% endblock %}
         {% block mib_scalar_object_instantiation scoped %}
-{{ symbol|replace('-', '_') }} = _{{ symbol|replace('-', '_')|capfirst }}_Object(
+{{ symbol }} = _{{ symbol|capfirst }}_Object(
     {{ definition['oid'] }},
-    _{{ symbol|replace('-', '_')|capfirst }}_Type()
+    _{{ symbol|capfirst }}_Type()
 )
         {% endblock %}
-{{ symbol|replace('-', '_') }}.setMaxAccess("{{ definition['maxaccess'] }}")
+{{ symbol }}.setMaxAccess("{{ definition['maxaccess'] }}")
     {% elif definition['nodetype'] == 'table' %}
         {% block mib_table_object_definition scoped %}
-_{{ symbol|replace('-', '_')|capfirst }}_Object = MibTable
+_{{ symbol|capfirst }}_Object = MibTable
         {% endblock %}
         {% block mib_table_object_instantiation scoped %}
-{{ symbol|replace('-', '_') }} = _{{ symbol|replace('-', '_')|capfirst }}_Object(
+{{ symbol }} = _{{ symbol|capfirst }}_Object(
     {{ definition['oid'] }}
 )
         {% endblock %}
     {% elif definition['nodetype'] == 'row' %}
         {% block mib_table_row_object_definition scoped %}
-_{{ symbol|replace('-', '_')|capfirst }}_Object = MibTableRow
+_{{ symbol|capfirst }}_Object = MibTableRow
         {% endblock %}
         {% block mib_table_row_object_instantiation scoped %}
-{{ symbol|replace('-', '_') }} = _{{ symbol|replace('-', '_')|capfirst }}_Object(
+{{ symbol }} = _{{ symbol|capfirst }}_Object(
     {{ definition['oid'] }}
 )
         {% endblock %}
         {% if 'indices' in definition %}
-{{ symbol|replace('-', '_') }}.setIndexNames(
+{{ symbol }}.setIndexNames(
             {% for index in definition['indices'] %}
     ({{ index['implied'] }}, "{{ index['module'] }}", "{{ index['object'] }}"),
             {% endfor %}
@@ -329,33 +329,33 @@ _{{ symbol|replace('-', '_')|capfirst }}_Object = MibTableRow
         {% endif %}
     {% elif definition['nodetype'] == 'column' %}
         {% block mib_table_column_object_definition scoped %}
-_{{ symbol|replace('-', '_')|capfirst }}_Object = MibTableColumn
+_{{ symbol|capfirst }}_Object = MibTableColumn
         {% endblock %}
         {% block mib_table_column_object_instantiation scoped %}
-{{ symbol|replace('-', '_') }} = _{{ symbol|replace('-', '_')|capfirst }}_Object(
+{{ symbol }} = _{{ symbol|capfirst }}_Object(
     {{ definition['oid'] }},
-    _{{ symbol|replace('-', '_')|capfirst }}_Type()
+    _{{ symbol|capfirst }}_Type()
 )
         {% endblock %}
-{{ symbol|replace('-', '_') }}.setMaxAccess("{{ definition['maxaccess'] }}")
+{{ symbol }}.setMaxAccess("{{ definition['maxaccess'] }}")
     {% endif %}
     {% if 'status' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setStatus("{{ definition['status'] }}")
+    {{ symbol }}.setStatus("{{ definition['status'] }}")
     {% endif %}
     {% if 'units' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setUnits("{{ definition['units'] }}")
+    {{ symbol }}.setUnits("{{ definition['units'] }}")
     {% endif %}
     {% if 'reference' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setReference("""\
+    {{ symbol }}.setReference("""\
 {{ definition['reference']|wordwrap }}
 """)
     {% endif %}
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setDescription("""\
+    {{ symbol }}.setDescription("""\
 {{ definition['description']|wordwrap }}
 """)
     {% endif %}
@@ -366,9 +366,9 @@ if mibBuilder.loadTexts:
    and 'augmention' in definition %}
 {{ definition['augmention']['object'] }}.registerAugmentions(
     ("{{ mib['meta']['module'] }}",
-     "{{ symbol|replace('-', '_') }}")
+     "{{ symbol }}")
 )
-{{ symbol|replace('-', '_') }}.setIndexNames(*{{ definition['augmention']['object'] }}.getIndexNames())
+{{ symbol }}.setIndexNames(*{{ definition['augmention']['object'] }}.getIndexNames())
 {% endfor %}
 {% endblock -%}
 
@@ -378,11 +378,11 @@ if mibBuilder.loadTexts:
 
 {% for symbol, definition in mib.items()
    if definition['class'] == 'objectgroup' %}
-{{ symbol|replace('-', '_') }} = ObjectGroup(
+{{ symbol }} = ObjectGroup(
     {{ definition['oid'] }}
 )
     {% if 'objects' in definition %}
-{{ symbol|replace('-', '_') }}.setObjects(
+{{ symbol }}.setObjects(
     {% for obj in definition['objects'] %}
         {% if loop.first and loop.last %}
     ("{{ obj['module'] }}", "{{  obj['object'] }}")
@@ -397,10 +397,10 @@ if mibBuilder.loadTexts:
 )
     {% endif %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setStatus("{{ definition['status'] }}")
+    {{ symbol }}.setStatus("{{ definition['status'] }}")
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setDescription("""\
+    {{ symbol }}.setDescription("""\
 {{ definition['description']|wordwrap }}
 """)
     {% endif %}
@@ -414,11 +414,11 @@ if mibBuilder.loadTexts:
 
 {% for symbol, definition in mib.items()
    if definition['class'] == 'notificationtype' %}
-{{ symbol|replace('-', '_') }} = NotificationType(
+{{ symbol }} = NotificationType(
     {{ definition['oid'] }}
 )
     {% if 'objects' in definition %}
-{{ symbol|replace('-', '_') }}.setObjects(
+{{ symbol }}.setObjects(
     {% for obj in definition['objects'] %}
         {% if loop.first and loop.last %}
     ("{{ obj['module'] }}", "{{  obj['object'] }}")
@@ -433,12 +433,12 @@ if mibBuilder.loadTexts:
 )
     {% endif %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setStatus(
+    {{ symbol }}.setStatus(
         "{{ definition['status'] }}"
     )
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setDescription("""\
+    {{ symbol }}.setDescription("""\
 {{ definition['description']|wordwrap }}
 """)
     {% endif %}
@@ -452,11 +452,11 @@ if mibBuilder.loadTexts:
 
 {% for symbol, definition in mib.items()
    if definition['class'] == 'notificationgroup' %}
-{{ symbol|replace('-', '_') }} = NotificationGroup(
+{{ symbol }} = NotificationGroup(
     {{ definition['oid'] }}
 )
     {% if 'objects' in definition %}
-{{ symbol|replace('-', '_') }}.setObjects(
+{{ symbol }}.setObjects(
     {% for obj in definition['objects'] %}
         {% if loop.first and loop.last %}
     ("{{ obj['module'] }}", "{{  obj['object'] }}")
@@ -471,12 +471,12 @@ if mibBuilder.loadTexts:
 )
     {% endif %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setStatus(
+    {{ symbol }}.setStatus(
         "{{ definition['status'] }}"
     )
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setDescription("""\
+    {{ symbol }}.setDescription("""\
 {{ definition['description']|wordwrap }}
 """)
     {% endif %}
@@ -490,28 +490,28 @@ if mibBuilder.loadTexts:
 
 {% for symbol, definition in mib.items()
    if definition['class'] == 'agentcapabilities' %}
-{{ symbol|replace('-', '_') }} = AgentCapabilities(
+{{ symbol }} = AgentCapabilities(
     {{ definition['oid'] }}
 )
     {% if 'productrelease' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setProductRelease(
+    {{ symbol }}.setProductRelease(
         "{{ definition['productrelease'] }}"
     )
     {% endif %}
     {% if 'reference' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setReference(
+    {{ symbol }}.setReference(
         "{{ definition['reference'] }}"
     )
     {% endif %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setStatus(
+    {{ symbol }}.setStatus(
         "{{ definition['status'] }}"
     )
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setDescription("""\
+    {{ symbol }}.setDescription("""\
 {{ definition['description']|wordwrap }}
 """)
     {% endif %}
@@ -525,11 +525,11 @@ if mibBuilder.loadTexts:
 
 {% for symbol, definition in mib.items()
    if definition['class'] == 'modulecompliance' %}
-{{ symbol|replace('-', '_') }} = ModuleCompliance(
+{{ symbol }} = ModuleCompliance(
     {{ definition['oid'] }}
 )
     {% if 'objects' in definition %}
-{{ symbol|replace('-', '_') }}.setObjects(
+{{ symbol }}.setObjects(
     {% for obj in definition['objects'] %}
         {% if loop.first and loop.last %}
     ("{{ obj['module'] }}", "{{  obj['object'] }}")
@@ -544,12 +544,12 @@ if mibBuilder.loadTexts:
 )
     {% endif %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setStatus(
+    {{ symbol }}.setStatus(
         "{{ definition['status'] }}"
     )
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:
-    {{ symbol|replace('-', '_') }}.setDescription("""\
+    {{ symbol }}.setDescription("""\
 {{ definition['description']|wordwrap }}
 """)
     {% endif %}
@@ -570,13 +570,13 @@ mibBuilder.exportSymbols(
                                   'notificationtype', 'objectgroup',
                                   'objectidentity', 'textualconvention') %}
         {% if loop.first and loop.last %}
-    **{"{{ symbol }}": {{ symbol|replace('-', '_') }}}
+    **{"{{ definition['name'] }}": {{ symbol }}}
         {% elif loop.first %}
-    **{"{{ symbol }}": {{ symbol|replace('-', '_') }},
+    **{"{{ definition['name'] }}": {{ symbol }},
         {% elif loop.last %}
-       "{{ symbol }}": {{ symbol|replace('-', '_') }}}
+       "{{ definition['name'] }}": {{ symbol }}}
         {% else %}
-       "{{ symbol }}": {{ symbol|replace('-', '_') }},
+       "{{ definition['name'] }}": {{ symbol }},
         {% endif %}
     {%  endfor %}
 )

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -568,7 +568,8 @@ mibBuilder.exportSymbols(
                                   'agentcapabilities', 'moduleidentity',
                                   'modulecompliance', 'notificationgroup',
                                   'notificationtype', 'objectgroup',
-                                  'objectidentity', 'textualconvention') %}
+                                  'objectidentity', 'textualconvention',
+                                  'type') %}
         {% if loop.first and loop.last %}
     **{"{{ definition['name'] }}": {{ symbol }}}
         {% elif loop.first %}

--- a/pysmi/codegen/templates/pysnmp/mib-instrumentation/managed-objects-instances.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-instrumentation/managed-objects-instances.j2
@@ -19,7 +19,7 @@ your code into these hooks.
 {% block mib_scalar_object_instance_definition %}
 
 
-class {{ symbol|replace('-', '_')|capfirst }}_ObjectInstance(MibScalarInstance):
+class {{ symbol|capfirst }}_ObjectInstance(MibScalarInstance):
     """Scalar Managed Object Instance with MIB instrumentation hooks.
 
     User can override none, some or all of the method below interfacing
@@ -90,7 +90,7 @@ class {{ symbol|replace('-', '_')|capfirst }}_ObjectInstance(MibScalarInstance):
 {% block mib_table_column_object_instance_definition %}
 
 
-class {{ symbol|replace('-', '_')|capfirst }}_ObjectInstance(MibScalarInstance):
+class {{ symbol|capfirst }}_ObjectInstance(MibScalarInstance):
     """Columnar Managed Object Instance with MIB instrumentation hooks.
 
     User can override none, some or all of the method below interfacing
@@ -175,4 +175,3 @@ class {{ symbol|replace('-', '_')|capfirst }}_ObjectInstance(MibScalarInstance):
 
 
 {% endblock %}
-

--- a/pysmi/codegen/templates/pysnmp/mib-instrumentation/managed-objects.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-instrumentation/managed-objects.j2
@@ -20,7 +20,7 @@ your code into these hooks.
 {% block mib_scalar_object_definition %}
 
 
-class _{{ symbol|replace('-', '_')|capfirst }}_Object(MibScalar):
+class _{{ symbol|capfirst }}_Object(MibScalar):
     """Scalar MIB object with MIB instrumentation hooks.
 
     User can override none, some or all of the method below interfacing
@@ -90,7 +90,7 @@ class _{{ symbol|replace('-', '_')|capfirst }}_Object(MibScalar):
 {% block mib_table_column_object_definition %}
 
 
-class _{{ symbol|replace('-', '_')|capfirst }}_Object(MibScalar):
+class _{{ symbol|capfirst }}_Object(MibScalar):
     """Columnar MIB object with MIB instrumentation hooks.
 
     User can override none, some or all of the method below interfacing

--- a/pysmi/compiler.py
+++ b/pysmi/compiler.py
@@ -211,6 +211,7 @@ class MibCompiler:
         symbolTableMap = {}
         mibsToParse = [x for x in mibnames]
         canonicalMibNames = {}
+        seenMibNames = set()
 
         while mibsToParse:
             mibname = mibsToParse.pop(0)
@@ -226,6 +227,14 @@ class MibCompiler:
                     f"MIB {mibname} already failed"
                 )
                 continue
+
+            if mibname in seenMibNames:
+                debug.logger & debug.flagCompiler and debug.logger(
+                    f"MIB {mibname} already seen (cyclic dependency)"
+                )
+                continue
+
+            seenMibNames.add(mibname)
 
             for source in self._sources:
                 debug.logger & debug.flagCompiler and debug.logger(

--- a/pysmi/compiler.py
+++ b/pysmi/compiler.py
@@ -298,7 +298,9 @@ class MibCompiler:
                 if mibname not in processed:
                     processed[mibname] = statusMissing
 
-        print(f"MIBs analyzed {len(parsedMibs)}, MIBs failed {len(failedMibs)}")
+        debug.logger & debug.flagCompiler and debug.logger(
+            f"MIBs analyzed {len(parsedMibs)}, MIBs failed {len(failedMibs)}"
+        )
 
         #
         # See what MIBs need generating

--- a/pysmi/parser/smi.py
+++ b/pysmi/parser/smi.py
@@ -761,7 +761,7 @@ class SmiV2Parser(AbstractParser):
     def p_DefValPart(self, p):
         """DefValPart : DEFVAL '{' Value '}'
         | empty"""
-        if p[1] and p[3]:
+        if p[1] and p[3] is not None:
             p[0] = (p[1], p[3])
 
     def p_Value(self, p):
@@ -776,8 +776,7 @@ class SmiV2Parser(AbstractParser):
     def p_BitsValue(self, p):
         """BitsValue : BitNames
         | empty"""
-        if p[1]:
-            p[0] = p[1]
+        p[0] = p[1] or []
 
     def p_BitNames(self, p):
         """BitNames : BitNames ',' LOWERCASE_IDENTIFIER

--- a/pysmi/parser/smi.py
+++ b/pysmi/parser/smi.py
@@ -105,7 +105,7 @@ class SmiV2Parser(AbstractParser):
         p[0] = (
             p[1],  # name
             p[2],  # oid
-            p[7],  # linkage (imports)
+            p[7] or {},  # linkage (imports)
             p[8],
         )  # declaration
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -21,6 +21,7 @@ suite = unittest.TestLoader().loadTestsFromNames(
         "test_notificationtype_smiv2_pysnmp",
         "test_objectgroup_smiv2_pysnmp",
         "test_objectidentity_smiv2_pysnmp",
+        "test_objecttype_smiv1_pysnmp",
         "test_objecttype_smiv2_pysnmp",
         "test_smiv1_smiv2_pysnmp",
         "test_traptype_smiv2_pysnmp",

--- a/tests/test_agentcapabilities_smiv2_pysnmp.py
+++ b/tests/test_agentcapabilities_smiv2_pysnmp.py
@@ -28,7 +28,7 @@ class AgentCapabilitiesTestCase(unittest.TestCase):
             FROM SNMPv2-CONF;
 
     testCapability AGENT-CAPABILITIES
-        PRODUCT-RELEASE "Test produce"
+        PRODUCT-RELEASE "Test product"
         STATUS          current
         DESCRIPTION
             "test capabilities"
@@ -89,6 +89,43 @@ class AgentCapabilitiesTestCase(unittest.TestCase):
             self.ctx["testCapability"].__class__.__name__,
             "AgentCapabilities",
             "bad SYNTAX class",
+        )
+
+
+class AgentCapabilitiesHyphenTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+        AGENT-CAPABILITIES
+            FROM SNMPv2-CONF;
+
+    test-capability AGENT-CAPABILITIES
+        PRODUCT-RELEASE "Test product"
+        STATUS          current
+        DESCRIPTION
+            "test capabilities"
+
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().genCode(ast, {})
+        self.mibInfo, pycode = PySnmpCodeGen().genCode(ast, {mibInfo.name: symtable})
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testAgentCapabilitiesSymbol(self):
+        self.assertTrue("test_capability" in self.ctx, "symbol not present")
+
+    def testAgentCapabilitiesLabel(self):
+        self.assertEqual(
+            self.ctx["test_capability"].getLabel(), "test-capability", "bad label"
         )
 
 

--- a/tests/test_imports_smiv1_pysnmp.py
+++ b/tests/test_imports_smiv1_pysnmp.py
@@ -1,0 +1,129 @@
+#
+# This file is part of pysmi software.
+#
+# Copyright (c) 2015-2020, Ilya Etingof; Copyright 2022-2024, others
+# License: https://www.pysnmp.com/pysmi/license.html
+#
+import sys
+
+try:
+    import unittest2 as unittest
+
+except ImportError:
+    import unittest
+
+from pysmi.parser.smi import parserFactory
+from pysmi.codegen.pysnmp import PySnmpCodeGen
+from pysmi.codegen.symtable import SymtableCodeGen
+from pysnmp.smi.builder import MibBuilder
+
+
+class ImportConversionTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    -- Import one from each conversion category. Note that we cannot test that
+    -- the imports "internet", "snmp", and "nullSpecific" can also be used, as
+    -- that requires actually parsing SNMPv2-SMI.
+    IMPORTS
+      internet
+        FROM RFC1065-SMI
+      Gauge
+        FROM RFC1155-SMI
+      snmp, nullSpecific
+        FROM RFC1158-MIB
+      DisplayString, PhysAddress
+        FROM RFC1213-MIB
+      OBJECT-TYPE
+        FROM RFC-1212
+      TRAP-TYPE
+        FROM RFC-1215;
+
+    testObjectType1 OBJECT-TYPE
+        SYNTAX          Gauge
+        ACCESS          read-only
+        STATUS          mandatory
+        DESCRIPTION     "Test object"
+      ::= { 1 3 }
+
+    testObjectType2 OBJECT-TYPE
+        SYNTAX          DisplayString
+        ACCESS          read-only
+        STATUS          mandatory
+        DESCRIPTION     "Test object"
+      ::= { 1 4 }
+
+    testObjectType3 OBJECT-TYPE
+        SYNTAX          PhysAddress
+        ACCESS          read-only
+        STATUS          mandatory
+        DESCRIPTION     "Test object"
+      ::= { 1 5 }
+
+    trapBase OBJECT IDENTIFIER ::= { 1 6 }
+
+    testTrap TRAP-TYPE
+        ENTERPRISE      trapBase
+      ::= 2
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().genCode(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().genCode(
+            ast, {mibInfo.name: symtable}, genTexts=True
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testImportedSymbol1(self):
+        self.assertTrue("internet" in self.ctx, "imported symbol not present")
+
+    def testImportedSymbol2(self):
+        self.assertTrue("Gauge32" in self.ctx, "imported symbol not present")
+
+    def testImportedSymbol3(self):
+        self.assertTrue("snmp" in self.ctx, "imported symbol not present")
+
+    def testImportedSymbol4(self):
+        self.assertTrue("zeroDotZero" in self.ctx, "imported symbol not present")
+
+    def testImportedSymbol5(self):
+        self.assertTrue("DisplayString" in self.ctx, "imported symbol not present")
+
+    def testImportedSymbol6(self):
+        self.assertTrue("PhysAddress" in self.ctx, "imported symbol not present")
+
+    def testObjectTypeSyntax1(self):
+        self.assertEqual(
+            self.ctx["testObjectType1"].getSyntax().__class__.__name__,
+            "Gauge32",
+            "bad syntax",
+        )
+
+    def testObjectTypeSyntax2(self):
+        self.assertEqual(
+            self.ctx["testObjectType2"].getSyntax().__class__.__name__,
+            "DisplayString",
+            "bad syntax",
+        )
+
+    def testObjectTypeSyntax3(self):
+        self.assertEqual(
+            self.ctx["testObjectType3"].getSyntax().__class__.__name__,
+            "PhysAddress",
+            "bad syntax",
+        )
+
+    def testTrapTypeName(self):
+        self.assertEqual(self.ctx["testTrap"].getName(), (1, 6, 0, 2), "bad name")
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == "__main__":
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/test_imports_smiv1_pysnmp.py
+++ b/tests/test_imports_smiv1_pysnmp.py
@@ -123,6 +123,33 @@ class ImportConversionTestCase(unittest.TestCase):
         self.assertEqual(self.ctx["testTrap"].getName(), (1, 6, 0, 2), "bad name")
 
 
+class ImportAbsentTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+
+    TestType ::= INTEGER
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().genCode(ast, {})
+        self.mibInfo, pycode = PySnmpCodeGen().genCode(ast, {mibInfo.name: symtable})
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testTypeClass(self):
+        self.assertEqual(
+            self.ctx["TestType"].__bases__[0].__name__,
+            "Integer32",
+            "bad type",
+        )
+
+
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
 
 if __name__ == "__main__":

--- a/tests/test_modulecompliance_smiv2_pysnmp.py
+++ b/tests/test_modulecompliance_smiv2_pysnmp.py
@@ -65,7 +65,7 @@ class ModuleComplianceTestCase(unittest.TestCase):
     def testModuleComplianceDescription(self):
         self.assertEqual(
             self.ctx["testCompliance"].getDescription(),
-            "This is the MIB compliance statement\n",
+            "This is the MIB compliance statement",
             "bad DESCRIPTION",
         )
 

--- a/tests/test_notificationgroup_smiv2_pysnmp.py
+++ b/tests/test_notificationgroup_smiv2_pysnmp.py
@@ -77,6 +77,46 @@ class NotificationGroupTestCase(unittest.TestCase):
         )
 
 
+class NotificationGroupHyphenTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      NOTIFICATION-GROUP
+        FROM SNMPv2-CONF;
+
+    test-notification-group NOTIFICATION-GROUP
+       NOTIFICATIONS    {
+                            testStatusChangeNotify
+                        }
+        STATUS          current
+        DESCRIPTION
+            "A collection of test notifications."
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().genCode(ast, {})
+        self.mibInfo, pycode = PySnmpCodeGen().genCode(ast, {mibInfo.name: symtable})
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testNotificationGroupSymbol(self):
+        self.assertTrue("test_notification_group" in self.ctx, "symbol not present")
+
+    def testNotificationGroupLabel(self):
+        self.assertEqual(
+            self.ctx["test_notification_group"].getLabel(),
+            "test-notification-group",
+            "bad label",
+        )
+
+
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
 
 if __name__ == "__main__":

--- a/tests/test_notificationgroup_smiv2_pysnmp.py
+++ b/tests/test_notificationgroup_smiv2_pysnmp.py
@@ -65,7 +65,7 @@ class NotificationGroupTestCase(unittest.TestCase):
     def testNotificationGroupDescription(self):
         self.assertEqual(
             self.ctx["testNotificationGroup"].getDescription(),
-            "A collection of test notifications.\n",
+            "A collection of test notifications.",
             "bad DESCRIPTION",
         )
 

--- a/tests/test_notificationtype_smiv2_pysnmp.py
+++ b/tests/test_notificationtype_smiv2_pysnmp.py
@@ -74,6 +74,47 @@ class NotificationTypeTestCase(unittest.TestCase):
         )
 
 
+class NotificationTypeHyphenTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      NOTIFICATION-TYPE
+        FROM SNMPv2-SMI;
+
+    test-notification-type NOTIFICATION-TYPE
+       OBJECTS         {
+                            testChangeConfigType,
+                            testChangeConfigValue
+                        }
+        STATUS          current
+        DESCRIPTION
+            "A collection of test notification types."
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().genCode(ast, {})
+        self.mibInfo, pycode = PySnmpCodeGen().genCode(ast, {mibInfo.name: symtable})
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testNotificationTypeSymbol(self):
+        self.assertTrue("test_notification_type" in self.ctx, "symbol not present")
+
+    def testNotificationTypeLabel(self):
+        self.assertEqual(
+            self.ctx["test_notification_type"].getLabel(),
+            "test-notification-type",
+            "bad name",
+        )
+
+
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
 
 if __name__ == "__main__":

--- a/tests/test_notificationtype_smiv2_pysnmp.py
+++ b/tests/test_notificationtype_smiv2_pysnmp.py
@@ -62,7 +62,7 @@ class NotificationTypeTestCase(unittest.TestCase):
     def testNotificationTypeDescription(self):
         self.assertEqual(
             self.ctx["testNotificationType"].getDescription(),
-            "A collection of test notification types.\n",
+            "A collection of test notification types.",
             "bad DESCRIPTION",
         )
 

--- a/tests/test_objectgroup_smiv2_pysnmp.py
+++ b/tests/test_objectgroup_smiv2_pysnmp.py
@@ -82,6 +82,45 @@ class ObjectGroupTestCase(unittest.TestCase):
         )
 
 
+class ObjectGroupHyphenTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-GROUP
+        FROM SNMPv2-CONF;
+
+    test-object-group OBJECT-GROUP
+        OBJECTS         {
+                            testStorageType,
+                            testRowStatus
+                        }
+        STATUS          current
+        DESCRIPTION
+            "A collection of test objects."
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory(**smiV2)().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().genCode(ast, {})
+        self.mibInfo, pycode = PySnmpCodeGen().genCode(ast, {mibInfo.name: symtable})
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectGroupSymbol(self):
+        self.assertTrue("test_object_group" in self.ctx, "symbol not present")
+
+    def testObjectGroupLabel(self):
+        self.assertEqual(
+            self.ctx["test_object_group"].getLabel(), "test-object-group", "bad label"
+        )
+
+
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
 
 if __name__ == "__main__":

--- a/tests/test_objectgroup_smiv2_pysnmp.py
+++ b/tests/test_objectgroup_smiv2_pysnmp.py
@@ -63,7 +63,7 @@ class ObjectGroupTestCase(unittest.TestCase):
     def testObjectGroupDescription(self):
         self.assertEqual(
             self.ctx["testObjectGroup"].getDescription(),
-            "A collection of test objects.\n",
+            "A collection of test objects.",
             "bad DESCRIPTION",
         )
 

--- a/tests/test_objectidentity_smiv2_pysnmp.py
+++ b/tests/test_objectidentity_smiv2_pysnmp.py
@@ -59,14 +59,12 @@ class ObjectIdentityTestCase(unittest.TestCase):
     def testObjectIdentityDescription(self):
         self.assertEqual(
             self.ctx["testObject"].getDescription(),
-            "Initial version\n",
+            "Initial version",
             "bad DESCRIPTION",
         )
 
     def testObjectIdentityReference(self):
-        self.assertEqual(
-            self.ctx["testObject"].getReference(), "ABC\n", "bad REFERENCE"
-        )
+        self.assertEqual(self.ctx["testObject"].getReference(), "ABC", "bad REFERENCE")
 
     def testObjectIdentityClass(self):
         self.assertEqual(

--- a/tests/test_objectidentity_smiv2_pysnmp.py
+++ b/tests/test_objectidentity_smiv2_pysnmp.py
@@ -76,6 +76,39 @@ class ObjectIdentityTestCase(unittest.TestCase):
         )
 
 
+class ObjectIdentityHyphenTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+        OBJECT-IDENTITY
+    FROM SNMPv2-SMI;
+
+    test-object OBJECT-IDENTITY
+        STATUS          current
+        DESCRIPTION     "Initial version"
+
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().genCode(ast, {})
+        self.mibInfo, pycode = PySnmpCodeGen().genCode(ast, {mibInfo.name: symtable})
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectIdentitySymbol(self):
+        self.assertTrue("test_object" in self.ctx, "symbol not present")
+
+    def testObjectIdentityLabel(self):
+        self.assertEqual(self.ctx["test_object"].getLabel(), "test-object", "bad label")
+
+
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
 
 if __name__ == "__main__":

--- a/tests/test_objecttype_smiv1_pysnmp.py
+++ b/tests/test_objecttype_smiv1_pysnmp.py
@@ -1,0 +1,413 @@
+#
+# This file is part of pysmi software.
+#
+# Copyright (c) 2015-2020, Ilya Etingof; Copyright 2022-2024, others
+# License: https://www.pysnmp.com/pysmi/license.html
+#
+import sys
+
+try:
+    import unittest2 as unittest
+
+except ImportError:
+    import unittest
+
+from pysmi.parser.smi import parserFactory
+from pysmi.parser.dialect import smiV1Relaxed
+from pysmi.codegen.pysnmp import PySnmpCodeGen
+from pysmi.codegen.symtable import SymtableCodeGen
+from pysnmp.smi.builder import MibBuilder
+
+
+class ObjectTypeMibTableTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-TYPE
+        FROM RFC-1212;
+
+      testTable OBJECT-TYPE
+        SYNTAX          SEQUENCE OF TestEntry
+        ACCESS          not-accessible
+        STATUS          mandatory
+        DESCRIPTION     "Test table"
+      ::= { 1 3 }
+
+      testEntry OBJECT-TYPE
+        SYNTAX          TestEntry
+        ACCESS          not-accessible
+        STATUS          mandatory
+        DESCRIPTION     "Test row"
+        INDEX           { INTEGER }
+      ::= { testTable 1 }
+
+      TestEntry ::= SEQUENCE {
+            testIndex   INTEGER,
+            testValue   OCTET STRING
+      }
+
+      testIndex OBJECT-TYPE
+        SYNTAX          INTEGER
+        ACCESS          read-write
+        STATUS          mandatory
+        DESCRIPTION     "Test column"
+      ::= { testEntry 1 }
+
+      testValue OBJECT-TYPE
+        SYNTAX          OCTET STRING
+        ACCESS          read-write
+        STATUS          mandatory
+        DESCRIPTION     "Test column"
+      ::= { testEntry 2 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory(**smiV1Relaxed)().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().genCode(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().genCode(
+            ast, {mibInfo.name: symtable}, genTexts=True
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        mibBuilder = MibBuilder()
+        mibBuilder.loadTexts = True
+
+        self.ctx = {"mibBuilder": mibBuilder}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectTypeTableClass(self):
+        self.assertEqual(
+            self.ctx["testTable"].__class__.__name__, "MibTable", "bad table class"
+        )
+
+    def testObjectTypeTableRowClass(self):
+        self.assertEqual(
+            self.ctx["testEntry"].__class__.__name__,
+            "MibTableRow",
+            "bad table row class",
+        )
+
+    def testObjectTypeTableColumnClass(self):
+        self.assertEqual(
+            self.ctx["testIndex"].__class__.__name__,
+            "MibTableColumn",
+            "bad table column class",
+        )
+
+    def testObjectTypeTableColumnAccess(self):
+        self.assertEqual(
+            self.ctx["testIndex"].getMaxAccess(),
+            "read-write",
+            "bad table column access",
+        )
+
+    def testObjectTypeTableColumnStatus(self):
+        self.assertEqual(
+            self.ctx["testIndex"].getStatus(), "mandatory", "bad table column status"
+        )
+
+    def testObjectTypeTableRowIndex(self):
+        self.assertEqual(
+            self.ctx["testEntry"].getIndexNames(),
+            ((0, "TEST-MIB", "pysmiFakeCol1"),),
+            "bad table index",
+        )
+
+    def testObjectTypeTableRowIndexClass(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol1"].__class__.__name__,
+            "MibTableColumn",
+            "bad index class",
+        )
+
+    def testObjectTypeTableRowIndexSyntax(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol1"].getSyntax().__class__.__name__,
+            "Integer32",
+            "bad index syntax",
+        )
+
+    def testObjectTypeTableRowIndexName(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol1"].getName(), (1, 3, 1, 4294967295), "bad index name"
+        )
+
+    def testObjectTypeTableRowIndexAccess(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol1"].getMaxAccess(),
+            "not-accessible",
+            "bad index access",
+        )
+
+    def testObjectTypeTableRowIndexStatus(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol1"].getStatus(), "mandatory", "bad index status"
+        )
+
+
+class ObjectTypeMibTableMultipleIndicesTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-TYPE
+        FROM RFC-1212;
+
+      testTable OBJECT-TYPE
+        SYNTAX          SEQUENCE OF TestEntry
+        ACCESS          not-accessible
+        STATUS          mandatory
+        DESCRIPTION     "Test table"
+      ::= { 1 3 }
+
+      testEntry OBJECT-TYPE
+        SYNTAX          TestEntry
+        ACCESS          not-accessible
+        STATUS          mandatory
+        DESCRIPTION     "Test row"
+        INDEX           { IpAddress, testIndex, OCTET STRING, NetworkAddress }
+      ::= { testTable 3 }
+
+      TestEntry ::= SEQUENCE {
+            testIndex   INTEGER,
+            testValue   OCTET STRING
+      }
+
+      testIndex OBJECT-TYPE
+        SYNTAX          INTEGER
+        ACCESS          not-accessible
+        STATUS          mandatory
+        DESCRIPTION     "Test column"
+      ::= { testEntry 1 }
+
+      testValue OBJECT-TYPE
+        SYNTAX          OCTET STRING
+        ACCESS          read-write
+        STATUS          mandatory
+        DESCRIPTION     "Test column"
+      ::= { testEntry 2 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory(**smiV1Relaxed)().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().genCode(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().genCode(
+            ast, {mibInfo.name: symtable}, genTexts=True
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        mibBuilder = MibBuilder()
+        mibBuilder.loadTexts = True
+
+        self.ctx = {"mibBuilder": mibBuilder}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectTypeTableRowIndex(self):
+        self.assertEqual(
+            self.ctx["testEntry"].getIndexNames(),
+            (
+                (0, "TEST-MIB", "pysmiFakeCol1"),
+                (0, "TEST-MIB", "testIndex"),
+                (0, "TEST-MIB", "pysmiFakeCol2"),
+                (0, "TEST-MIB", "pysmiFakeCol3"),
+            ),
+            "bad multiple table indices",
+        )
+
+    def testObjectTypeTableRowIndexClass1(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol1"].__class__.__name__,
+            "MibTableColumn",
+            "bad index class",
+        )
+
+    def testObjectTypeTableRowIndexSyntax1(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol1"].getSyntax().__class__.__name__,
+            "IpAddress",
+            "bad index syntax",
+        )
+
+    def testObjectTypeTableRowIndexName1(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol1"].getName(), (1, 3, 3, 4294967295), "bad index name"
+        )
+
+    def testObjectTypeTableRowIndexClassTest(self):
+        self.assertEqual(
+            self.ctx["testIndex"].__class__.__name__,
+            "MibTableColumn",
+            "bad index class",
+        )
+
+    def testObjectTypeTableRowIndexSyntaxTest(self):
+        self.assertEqual(
+            self.ctx["testIndex"].getSyntax().__class__.__name__,
+            "Integer32",
+            "bad index syntax",
+        )
+
+    def testObjectTypeTableRowIndexNameTest(self):
+        self.assertEqual(
+            self.ctx["testIndex"].getName(), (1, 3, 3, 1), "bad index name"
+        )
+
+    def testObjectTypeTableRowIndexClass2(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol2"].__class__.__name__,
+            "MibTableColumn",
+            "bad index class",
+        )
+
+    def testObjectTypeTableRowIndexSyntax2(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol2"].getSyntax().__class__.__name__,
+            "OctetString",
+            "bad index syntax",
+        )
+
+    def testObjectTypeTableRowIndexName2(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol2"].getName(), (1, 3, 3, 4294967294), "bad index name"
+        )
+
+    def testObjectTypeTableRowIndexClass3(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol3"].__class__.__name__,
+            "MibTableColumn",
+            "bad index class",
+        )
+
+    def testObjectTypeTableRowIndexSyntax3(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol3"].getSyntax().__class__.__name__,
+            "IpAddress",
+            "bad index syntax",
+        )
+
+    def testObjectTypeTableRowIndexName3(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol3"].getName(), (1, 3, 3, 4294967293), "bad index name"
+        )
+
+
+class ObjectTypeMultipleMibTablesTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-TYPE
+        FROM RFC-1212;
+
+      testTable OBJECT-TYPE
+        SYNTAX          SEQUENCE OF TestEntry
+        ACCESS          not-accessible
+        STATUS          mandatory
+        DESCRIPTION     "Test table"
+      ::= { 1 3 }
+
+      testEntry OBJECT-TYPE
+        SYNTAX          TestEntry
+        ACCESS          not-accessible
+        STATUS          mandatory
+        DESCRIPTION     "Test row"
+        INDEX           { INTEGER }
+      ::= { testTable 1 }
+
+      TestEntry ::= SEQUENCE {
+            testIndex   INTEGER
+      }
+
+      testIndex OBJECT-TYPE
+        SYNTAX          INTEGER
+        ACCESS          read-write
+        STATUS          mandatory
+        DESCRIPTION     "Test column"
+      ::= { testEntry 1 }
+
+      otherTable OBJECT-TYPE
+        SYNTAX          SEQUENCE OF OtherEntry
+        ACCESS          not-accessible
+        STATUS          mandatory
+        DESCRIPTION     "Test table"
+      ::= { 1 4 }
+
+      otherEntry OBJECT-TYPE
+        SYNTAX          OtherEntry
+        ACCESS          not-accessible
+        STATUS          mandatory
+        DESCRIPTION     "Test row"
+        INDEX           { OCTET STRING }
+      ::= { otherTable 1 }
+
+      OtherEntry ::= SEQUENCE {
+            otherValue   INTEGER
+      }
+
+      otherValue OBJECT-TYPE
+        SYNTAX          INTEGER
+        ACCESS          read-write
+        STATUS          mandatory
+        DESCRIPTION     "Test column"
+      ::= { otherEntry 2 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory(**smiV1Relaxed)().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().genCode(ast, {})
+        self.mibInfo, pycode = PySnmpCodeGen().genCode(ast, {mibInfo.name: symtable})
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectTypeTableRowIndexClass1(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol1"].__class__.__name__,
+            "MibTableColumn",
+            "bad index class",
+        )
+
+    def testObjectTypeTableRowIndexName1(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol1"].getName(), (1, 3, 1, 4294967295), "bad index name"
+        )
+
+    def testObjectTypeTableRowIndexSyntax1(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol1"].getSyntax().__class__.__name__,
+            "Integer32",
+            "bad index syntax",
+        )
+
+    def testObjectTypeTableRowIndexClass2(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol2"].__class__.__name__,
+            "MibTableColumn",
+            "bad index class",
+        )
+
+    def testObjectTypeTableRowIndexSyntax2(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol2"].getSyntax().__class__.__name__,
+            "OctetString",
+            "bad index syntax",
+        )
+
+    def testObjectTypeTableRowIndexName2(self):
+        self.assertEqual(
+            self.ctx["pysmiFakeCol2"].getName(), (1, 4, 1, 4294967295), "bad index name"
+        )
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == "__main__":
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/test_objecttype_smiv2_pysnmp.py
+++ b/tests/test_objecttype_smiv2_pysnmp.py
@@ -509,6 +509,51 @@ class ObjectTypeBitsDefaultEmptySetTestCase(unittest.TestCase):
         )
 
 
+class ObjectTypeObjectIdentifierTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-TYPE
+        FROM SNMPv2-SMI;
+
+    testTargetObjectType OBJECT-TYPE
+        SYNTAX          Integer32
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION     "Test target object"
+     ::= { 1 3 }
+
+    testObjectType OBJECT-TYPE
+        SYNTAX          OBJECT IDENTIFIER
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION     "Test object"
+        DEFVAL          { testTargetObjectType }
+     ::= { 1 4 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().genCode(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().genCode(
+            ast, {mibInfo.name: symtable}, genTexts=True
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectTypeSyntax(self):
+        self.assertEqual(
+            self.ctx["testObjectType"].getSyntax(),
+            (1, 3),
+            "bad DEFVAL",
+        )
+
+
 class ObjectTypeObjectIdentifierInvalidTestCase(unittest.TestCase):
     """
     TEST-MIB DEFINITIONS ::= BEGIN

--- a/tests/test_objecttype_smiv2_pysnmp.py
+++ b/tests/test_objecttype_smiv2_pysnmp.py
@@ -99,6 +99,43 @@ class ObjectTypeBasicTestCase(unittest.TestCase):
         )
 
 
+class ObjectTypeHyphenTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-TYPE
+        FROM SNMPv2-SMI;
+
+    test-object-type OBJECT-TYPE
+        SYNTAX          Integer32
+        UNITS           "seconds"
+        MAX-ACCESS      accessible-for-notify
+        STATUS          current
+        DESCRIPTION     "Test object"
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().genCode(ast, {})
+        self.mibInfo, pycode = PySnmpCodeGen().genCode(ast, {mibInfo.name: symtable})
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectTypeSymbol(self):
+        self.assertTrue("test_object_type" in self.ctx, "symbol not present")
+
+    def testObjectTypeLabel(self):
+        self.assertEqual(
+            self.ctx["test_object_type"].getLabel(), "test-object-type", "bad label"
+        )
+
+
 class ObjectTypeIntegerDefaultTestCase(unittest.TestCase):
     """
     TEST-MIB DEFINITIONS ::= BEGIN

--- a/tests/test_objecttype_smiv2_pysnmp.py
+++ b/tests/test_objecttype_smiv2_pysnmp.py
@@ -361,6 +361,82 @@ class ObjectTypeBitsTestCase(unittest.TestCase):
         )
 
 
+class ObjectTypeBitsDefaultTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-TYPE
+        FROM SNMPv2-SMI;
+
+    testObjectType OBJECT-TYPE
+        SYNTAX          BITS { present(0), absent(1), changed(2) }
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION     "Test object"
+        DEFVAL          { { present, absent } }
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().genCode(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().genCode(
+            ast, {mibInfo.name: symtable}, genTexts=True
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectTypeSyntax(self):
+        self.assertEqual(
+            self.ctx["testObjectType"].getSyntax(),
+            bytes((0xC0,)),
+            "bad DEFVAL",
+        )
+
+
+class ObjectTypeBitsDefaultMultiOctetTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-TYPE
+        FROM SNMPv2-SMI;
+
+    testObjectType OBJECT-TYPE
+        SYNTAX          BITS { a(0), b(1), c(2), d(3), e(4), f(5), g(6), h(7), i(8), j(9), k(10), l(11), m(12), n(13), o(14), p(15), q(16) }
+        MAX-ACCESS      read-only
+        STATUS          current
+        DESCRIPTION     "Test object"
+        DEFVAL          { { b, c, m } }
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().genCode(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().genCode(
+            ast, {mibInfo.name: symtable}, genTexts=True
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectTypeSyntax(self):
+        self.assertEqual(
+            self.ctx["testObjectType"].getSyntax(),
+            bytes((0x60, 0x08)),
+            "bad DEFVAL",
+        )
+
+
 class ObjectTypeMibTableTestCase(unittest.TestCase):
     """
     TEST-MIB DEFINITIONS ::= BEGIN

--- a/tests/test_smiv1_smiv2_pysnmp.py
+++ b/tests/test_smiv1_smiv2_pysnmp.py
@@ -71,7 +71,7 @@ class SmiV1TestCase(unittest.TestCase):
     def testSmiV1Description(self):
         self.assertEqual(
             self.ctx["testSmiV1"].getDescription(),
-            "A collection of test notifications.\n",
+            "A collection of test notifications.",
             "bad DESCRIPTION",
         )
 

--- a/tests/test_traptype_smiv2_pysnmp.py
+++ b/tests/test_traptype_smiv2_pysnmp.py
@@ -70,7 +70,7 @@ class TrapTypeTestCase(unittest.TestCase):
 
     def testTrapTypeDescription(self):
         self.assertEqual(
-            self.ctx["testTrap"].getDescription(), "Test trap\n", "bad DESCRIPTION"
+            self.ctx["testTrap"].getDescription(), "Test trap", "bad DESCRIPTION"
         )
 
     def testTrapTypeClass(self):

--- a/tests/test_typedeclaration_smiv1_pysnmp.py
+++ b/tests/test_typedeclaration_smiv1_pysnmp.py
@@ -17,6 +17,7 @@ from pysmi.parser.dialect import smiV1Relaxed
 from pysmi.codegen.pysnmp import PySnmpCodeGen
 from pysmi.codegen.symtable import SymtableCodeGen
 from pysnmp.smi.builder import MibBuilder
+from pysnmp.smi.view import MibViewController
 
 
 class TypeDeclarationTestCase(unittest.TestCase):
@@ -63,6 +64,8 @@ class TypeDeclarationTestCase(unittest.TestCase):
 
         exec(codeobj, self.ctx, self.ctx)
 
+        self.mibViewController = MibViewController(mibBuilder)
+
     def protoTestSymbol(self, symbol, klass):
         self.assertTrue(symbol in self.ctx, f"Symbol {symbol} not present")
 
@@ -71,6 +74,13 @@ class TypeDeclarationTestCase(unittest.TestCase):
             self.ctx[symbol].__bases__[0].__name__,
             klass,
             f"expected class {klass}, got {self.ctx[symbol].__bases__[0].__name__} at {symbol}",
+        )
+
+    def protoTestExport(self, symbol, klass):
+        self.assertEqual(
+            self.mibViewController.getTypeName(symbol),
+            ("TEST-MIB", symbol),
+            f"Symbol {symbol} not exported",
         )
 
 
@@ -106,6 +116,11 @@ for s, k in typesMap:
         TypeDeclarationTestCase,
         "testTypeDeclaration" + k + "ClassTestCase",
         decor(TypeDeclarationTestCase.protoTestClass, s, k),
+    )
+    setattr(
+        TypeDeclarationTestCase,
+        "testTypeDeclaration" + k + "ExportTestCase",
+        decor(TypeDeclarationTestCase.protoTestExport, s, k),
     )
 
 # XXX constraints flavor not checked

--- a/tests/test_typedeclaration_smiv2_pysnmp.py
+++ b/tests/test_typedeclaration_smiv2_pysnmp.py
@@ -111,39 +111,40 @@ class TypeDeclarationTestCase(unittest.TestCase):
             f"expected class {klass}, got {self.ctx[symbol].__bases__[0].__name__} at {symbol}",
         )
 
-    def TestTextualConventionSymbol(self):
+    def testTextualConventionSymbol(self):
         self.assertTrue("TestTextualConvention" in self.ctx, "symbol not present")
 
-    def TestTextualConventionDisplayHint(self):
+    def testTextualConventionDisplayHint(self):
         self.assertEqual(
-            self.ctx["TestTextualConvention"].getDisplayHint(),
+            self.ctx["TestTextualConvention"]().getDisplayHint(),
             "1x:",
             "bad DISPLAY-HINT",
         )
 
-    def TestTextualConventionStatus(self):
+    def testTextualConventionStatus(self):
         self.assertEqual(
-            self.ctx["TestTextualConvention"].getStatus(), "current", "bad STATUS"
+            self.ctx["TestTextualConvention"]().getStatus(), "current", "bad STATUS"
         )
 
-    def TestTextualConventionDescription(self):
+    def testTextualConventionDescription(self):
         self.assertEqual(
-            self.ctx["TestTextualConvention"].getDescription(),
+            self.ctx["TestTextualConvention"]().getDescription(),
             "Test TC\n",
             "bad DESCRIPTION",
         )
 
-    def TestTextualConventionReference(self):
+    def testTextualConventionReference(self):
         self.assertEqual(
-            self.ctx["TestTextualConvention"].getReference(),
-            "Test reference",
+            self.ctx["TestTextualConvention"]().getReference(),
+            "Test reference\n",
             "bad REFERENCE",
         )
 
-    def TestTextualConventionClass(self):
-        self.assertEqual(
-            self.ctx["TestTextualConvention"].__class__.__name__,
-            "TextualConvention",
+    def testTextualConventionClass(self):
+        self.assertTrue(
+            issubclass(
+                self.ctx["TestTextualConvention"], self.ctx["TextualConvention"]
+            ),
             "bad SYNTAX class",
         )
 

--- a/tests/test_valuedeclaration_smiv2_pysnmp.py
+++ b/tests/test_valuedeclaration_smiv2_pysnmp.py
@@ -28,9 +28,10 @@ class ValueDeclarationTestCase(unittest.TestCase):
 
     -- simple values
 
-    testValue1  OBJECT IDENTIFIER ::= { 1 }
-    testValue2  OBJECT IDENTIFIER ::= { testValue1 3 }
-    testValue3  OBJECT IDENTIFIER ::= { 1 3 6 1 2 }
+    testValue1    OBJECT IDENTIFIER ::= { 1 }
+    testValue2    OBJECT IDENTIFIER ::= { testValue1 3 }
+    testValue3    OBJECT IDENTIFIER ::= { 1 3 6 1 2 }
+    test-value-4  OBJECT IDENTIFIER ::= { 1 4 }
 
     -- testValue01  INTEGER ::= 123
     -- testValue02  INTEGER ::= -123
@@ -84,6 +85,17 @@ class ValueDeclarationTestCase(unittest.TestCase):
 
     def testValueDeclarationName3(self):
         self.assertEqual(self.ctx["testValue3"].getName(), (1, 3, 6, 1, 2), "bad value")
+
+    def testValueDeclarationLabel3(self):
+        self.assertEqual(self.ctx["testValue3"].getLabel(), "testValue3", "bad label")
+
+    def testValueDeclarationName4(self):
+        self.assertEqual(self.ctx["test_value_4"].getName(), (1, 4), "bad value")
+
+    def testValueDeclarationLabel4(self):
+        self.assertEqual(
+            self.ctx["test_value_4"].getLabel(), "test-value-4", "bad label"
+        )
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_valuedeclaration_smiv2_pysnmp.py
+++ b/tests/test_valuedeclaration_smiv2_pysnmp.py
@@ -32,6 +32,8 @@ class ValueDeclarationTestCase(unittest.TestCase):
     testValue2    OBJECT IDENTIFIER ::= { testValue1 3 }
     testValue3    OBJECT IDENTIFIER ::= { 1 3 6 1 2 }
     test-value-4  OBJECT IDENTIFIER ::= { 1 4 }
+    global        OBJECT IDENTIFIER ::= { 1 5 }
+    if            OBJECT IDENTIFIER ::= { global 2 }
 
     -- testValue01  INTEGER ::= 123
     -- testValue02  INTEGER ::= -123
@@ -96,6 +98,18 @@ class ValueDeclarationTestCase(unittest.TestCase):
         self.assertEqual(
             self.ctx["test_value_4"].getLabel(), "test-value-4", "bad label"
         )
+
+    def testValueDeclarationNameReservedKeyword(self):
+        self.assertEqual(self.ctx["_pysmi_global"].getName(), (1, 5), "bad value")
+
+    def testValueDeclarationLabelReservedKeyword(self):
+        self.assertEqual(self.ctx["_pysmi_global"].getLabel(), "global", "bad label")
+
+    def testValueDeclarationNameReservedKeyword2(self):
+        self.assertEqual(self.ctx["_pysmi_if"].getName(), (1, 5, 2), "bad value")
+
+    def testValueDeclarationLabelReservedKeyword2(self):
+        self.assertEqual(self.ctx["_pysmi_if"].getLabel(), "if", "bad label")
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])


### PR DESCRIPTION
# Summary

The [mibs.pysnmp.com](https://github.com/lextudio/mibs.pysnmp.com) collection of MIBs is a highly valuable test set for checking pysmi's support for real-world MIBs. In particular the pysmi post-v0.3.4 switch to Jinja2 template rendering appears to have caused a substantial regression, with the current pysmi version being able to compile and load only **65%** of the MIBs in the mibs.pysnmp.com collection.

This PR fixes a series of small pysmi issues and adds a few new forms of leniency for somewhat broken MIBs. As a result of this PR, pysmi is now able to compile and load **84%** of the MIBs in the mibs.pysnmp.com collection, with zero regressions. The included fixes also resolve a number of (open and recently closed) GitHub issues.

# The full story

The background of this PR is simply that I wanted to use pysmi to prepare a series of private MIBs for use with pysnmp, but I ran into various problems that had mostly also been reported as pysnmp issues already. Now that pysnmp and pysmi are thankfully being actively maintained again, I decided to spend some spare time on addressing the problems I ran into myself. I ended up fixing several other issues as well.

At some point I realized the value of the resurrected mibs.pysnmp.com MIBs collection. As of writing, that collection, in the asn1/ directory, consists of 11961 MIB files[^1]. Alongside, the pysnmp/ directory contains the compiled versions of those MIBs, to the extent that they could at any point be compiled at all. That directory contains 10713 compiled files right now, and out of those, 9903 can be successfully loaded by pysnmp today. Based on that, I think it is fair to state that the best that pysmi has ever done, is fully and properly support 9903 of the collection's 11961 MIB files, or just under 83%. According to their headers, the overwhelming majority of the compiled files have been generated by pysmi 0.3.4.

However, trying to compile and load the same collection of input MIBs with the current pysmi version (v1.4.4), with a few necessary base changes from this PR[^2], results in the following statistics:

> MIB results: 11961 total, 7806 successful, 1231 failed to compile, 2600 failed to load, 254 failed on dependency, 70 failed for other reasons

These results are produced by a simple program I put together for the occasion, rather than by mibdump (which, most importantly, will not try to load the produced files). In any case, these statistics are the basis for my above claim that the current version of pysmi supports merely 65% of the MIBs (7806 out of 11961). The main cause of the regression compared to pysmi 0.3.4 appears to be the conversion to the use of Jinja2 templates of [git-a42d1705](https://github.com/lextudio/pysmi/commit/a42d1705375f3844ba27dbf734e9d8c3a83abc1f). It appears that in several respects, that conversion was simply not fully finished.

With the fixes in this PR, which I offer for your consideration, the same test program produces the following output:

> MIB results: 11961 total, 10058 successful, 1024 failed to compile, 708 failed to load, 101 failed on dependency, 70 failed for other reasons

As can be seen, the PR enables the use of 2252 additional MIBs from the collection, now totaling 84% (10058 out of 11961). The additional successes represent a strict improvement: there are no cases where a MIB could be compiled and loaded before this PR but not after. Some MIBs have changed between "failed to compile" and "failed to load" in either direction, but of course, from the user's perspective it is not important as to whether a MIB fails to compile or its compiled form fails to load.

I have done manual inspection of a sizable subset of the changes to the MIBs' .py files as generated before and after the PR, to make sure that the improvements are not due to parts of generated code being unintentionally omitted. After all, taken to the extreme, an empty Python file will load perfectly fine too..! All changes that I have checked, are however intentional improvements. Note that such manual inspection is feasible only because of one of the commits in this PR. Verifying all the produced changes was not feasible however, as the full delta is close to 250 KLoC.

Strictly going by numbers, the PR improves the support for the collection beyond what is found in the mibs.pysnmp.com pysnmp/ directory (10058 instead of 9903). That would suggest that this PR improves pysmi to a "MIB tolerance level" never seen before, which does sound nice. However, it should be noted that the latter set is not a strict subset of the former set: there are 38 MIBs whose current mibs.pysnmp.com Python files load successfully, yet are still not part of the "success set" after this PR. Curiously, at least one case (Wellfleet-MIB) is because the ASN.1 MIB is different in contents from the MIB that was used to generate the compiled version. Many of the other cases can likely be resolved by adding a level of tolerance of capitalization differences in MIB file name versus internal MIB name; I have not looked into that yet.

For completeness: in the above results, "failed on dependency" refers to compile-time dependencies only, as load-time dependency failures are harder to filter out, so those are counted as load failures instead. The "failed for other reasons" category mainly covers cases where the compilation did not fail but also did not produce a Python file named after the input MIB file.

I have made available the test program itself [as a gist](https://gist.github.com/dcvmoole/073d2b6dcd313fd685e0e9cb9e60e9b2). The program is overly conservative in that it basically starts with a clean slate for every single MIB. In both cases reported above, it was run against the head of the mibs.pysnmp.com repo, which is currently [git-66c9072d](https://github.com/lextudio/mibs.pysnmp.com/commit/66c9072df9da3960b140189ce0fb72b7ab5af0c7). On my test system, a single full run takes about 3.5 hours.

# The pull request

The PR itself is split up into small commits in order to facilitate reviewing. Needless to say, I would be happy to address feedback.

Test cases are added where applicable: this PR increases the number of test cases from 114 to 251. Overall, the unit test set remains woefully inadequate for catching regressions, but at least the changes of this PR are covered.

The commits have been subjected to the repository's pre-commit hooks, including Black. As a side note, I noticed that running Black on the entire source tree ends up changing a lexer regex in such a way that pysmi becomes completely non-functional. That should probably be addressed at some point.

The commits have _not_ taken into account PyCharm's inspection facility. Even though pysmi has many annotations for that, those annotations also seem to be highly incomplete as they are. I am not a PyCharm user, but I did give its inspection a go; at the very least, it found no new errors.

The fixes in this PR fully resolve the following GitHub issues:

- [lextudio/pysnmp/issues/83](https://github.com/lextudio/pysnmp/issues/83) (open)
- [lextudio/pysnmp/issues/90](https://github.com/lextudio/pysnmp/issues/90) (closed but unaddressed)
- [lextudio/pysnmp/issues/91](https://github.com/lextudio/pysnmp/issues/91) (closed but unaddressed)
- [etingof/pysmi/issues/48](https://github.com/etingof/pysmi/issues/48) (open), as referenced in [lextudio/pysnmp/issues/54](https://github.com/lextudio/pysnmp/issues/54) (open)

It is perhaps worth noting that several of the commits in the PR make adjustments to the JSON output format as well, as side effect of necessary changes at the intermediate code generation level. It is my view that development of pysmi cannot move ahead without occasionally making breaking changes to the JSON format, although in that regard the impact of this PR is fortunately very limited anyway.

# Looking further ahead

This PR aims to cover much of the low-hanging fruit. With a few slightly more extensive pysmi changes, my current estimate is that it is possible to increase the number of fully supported MIBs from the mibs.pysnmp.com collection further by roughly 600 MIBs or about 5%, thereby bringing up the total to about 89%. Most of that increase would require two more future changes:

* Many MIBs use DEFVAL values that violate the constraints of their corresponding SYNTAX types. In such cases, pyasn1 will fail to instantiate the corresponding object as created by the MIB's compiled pysnmp code, thus resulting in a load failure. If pysmi were to detect such cases itself, it can drop the DEFVAL value altogether (as it already does in some cases), thus generating pysnmp code that can be loaded. Doing so would require pysmi's symbol table stage to save information on all constraints, rather than just a subset as it does now. This change would likely add support for a little over 300 MIBs.
* Many MIBs have broken imports. Some MIBs assume imports to be transitive (e.g., when MIB B imports symbol X from MIB A, MIB C expects to be able to import symbol X from MIB B). Some MIBs import symbols from the plain wrong MIB. Other MIBs import symbols that are not available anywhere, but are also not used. All these cases can be fixed with an extra import processing stage that modifies the import and symbol tables to redirect or remove imports. This change would add support for a little over 150 MIBs.

I'd certainly appreciate feedback as to whether such additional changes would be welcome, although I cannot make any promises myself. In any case, going substantially beyond the estimated 89% will be quite a bit harder, as that requires a next level of tolerance for problems with MIBs. Even then, getting anywhere near 100% is impossible without all processing stages (including the parser) being able to selectively discard any and all parts of the input that it cannot both validate and process. I would say that for pysmi, that is not a desirable goal.

[^1]: A handful of files are actually not MIB files, but some accompanying files that were probably accidentally extracted from an archive along with actual MIBs. For the purpose of the analysis presented here, they do not have a substantial impact.
[^2]: This "baseline" run makes use of the first three changes from this PR. Without those changes, the output would be messed up by debug messages, the run would get stuck as soon as it gets to A3Com-products-MIB, and the resulting .py files could not easily be compared for regressions. I have confirmed in several ways that these three changes do not affect the baseline statistics in any other way.