### PR TITLE
Fix for named values of BITS used via types

### DIFF
--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -151,6 +151,22 @@ if mibBuilder.loadTexts:
     {% endif %}
 {% endmacro -%}
 
+{% macro bits(namedbits) %}
+    namedValues = NamedValues(
+    {% for name, iden in namedbits.items()|sort %}
+        {% if loop.first and loop.last %}
+        ("{{ name}}", {{ iden }})
+        {% elif loop.first %}
+        *(("{{ name}}", {{ iden }}),
+        {% elif loop.last %}
+          ("{{ name}}", {{ iden }}))
+        {% else %}
+          ("{{ name}}", {{ iden }}),
+        {% endif %}
+    {% endfor %}
+    )
+{%- endmacro -%}
+
 {% macro default(definition) %}
     {% if definition['default']['default']['format'] == 'decimal' %}
     defaultValue = {{ definition['default']['default']['value'] }}
@@ -198,6 +214,9 @@ class {{ symbol }}({{ definition['type']['type'] }}):
     {% if 'constraints' in definition['type'] %}
 {{ constraints(definition['type']['type'], definition['type']['constraints']) }}
     {% endif %}
+    {% if 'bits' in definition['type'] %}
+{{ bits(definition['type']['bits']) }}
+    {% endif %}
 
 
 {%  endfor %}
@@ -217,6 +236,9 @@ class {{ symbol }}({{ definition['type']['type'] }}, TextualConvention):
     {% endif %}
     {% if 'constraints' in definition['type'] %}
 {{ constraints(definition['type']['type'], definition['type']['constraints']) }}
+    {% endif %}
+    {% if 'bits' in definition['type'] %}
+{{ bits(definition['type']['bits']) }}
     {% endif %}
     {% if 'description' in definition %}
     if mibBuilder.loadTexts:
@@ -250,19 +272,7 @@ class _{{ symbol|capfirst }}_Type({{ definition['syntax']['type'] }}):
 {{ constraints(definition['syntax']['type'], definition['syntax']['constraints']) }}
                 {% endif %}
                 {% if 'bits' in definition['syntax'] %}
-    namedValues = NamedValues(
-                    {% for name, iden in definition['syntax']['bits'].items()|sort %}
-                        {% if loop.first and loop.last %}
-        ("{{ name}}", {{ iden }})
-                        {% elif loop.first %}
-        *(("{{ name}}", {{ iden }}),
-                        {% elif loop.last %}
-          ("{{ name}}", {{ iden }}))
-                        {% else %}
-          ("{{ name}}", {{ iden }}),
-                        {% endif %}
-                    {% endfor %}
-    )
+{{ bits(definition['syntax']['bits']) }}
                 {% endif %}
 
                 {% if 'constraints' in definition['syntax'] or 'bits' in definition['syntax'] %}


### PR DESCRIPTION
This is a bugfix for an actual pysmi code generation problem that I ran into. Summarizing by example, the following (simplified) construction:

    someObject OBJECT-TYPE
        SYNTAX      BITS { bitZero(0), bitOne(1) }

...is parsed properly and makes available bitZero(0) and bitOne(1) for enumeration via `someObject.getSyntax().namedValues`, as it should. However, the following (effectively equivalent) alternative:

    MyTextualConvention ::= TEXTUAL-CONVENTION
        SYNTAX      BITS { bitZero(0), bitOne(1) }
    
    someObject OBJECT-TYPE
        SYNTAX      MyTextualConvention

...is also parsed properly, but does *not* make available bitZero(0) and bitOne(1) for enumeration via `someObject.getSyntax().namedValues`, nor in any other way for that matter. Such uses of types with BITS syntax are just as valid as using BITS directly, and so I can only conclude that this behavior is not intended. This issue seems to have been present since at least pysmi's switch to the use of a Jinja2 template. The problem is fortunately also limited to that template.

The attached fix addresses the problem, thus ensuring that the bit values also end up in `namedValues` in the second case. I have used my test script from PR #3 to ensure that this fix does not break anything in the mibs.pysnmp.com collection: the exact same statistics come out before and after. However, from that collection, 292 modules end up with additional named-values lists as a result of this fix, and I believe it is therefore purely an improvement for any users of those MIBs.