### PR TITLE
Fix support for display hints being applied

### DIFF
--- a/pysmi/codegen/symtable.py
+++ b/pysmi/codegen/symtable.py
@@ -351,12 +351,14 @@ class SymtableCodeGen(AbstractCodeGen):
         pysmiName = self.trans_opers(origName)
 
         if declaration:
-            parentType, attrs = declaration
+            parentType, attrs, isTC = declaration
+
             if parentType:  # skipping SEQUENCE case
                 symProps = {
                     "type": "TypeDeclaration",
-                    "syntax": declaration,  # (type, module), subtype
+                    "syntax": (parentType, attrs),  # (type, module), subtype
                     "origName": origName,
+                    "isTC": isTC,
                 }
 
                 self.reg_sym(pysmiName, symProps, [declaration[0][0]])
@@ -555,13 +557,15 @@ class SymtableCodeGen(AbstractCodeGen):
     def gen_type_declaration_rhs(self, data, classmode=False):
         if len(data) == 1:
             parentType, attrs = data[0]  # just syntax
+            isTC = False
 
         else:
             # Textual convention
             display, status, description, reference, syntax = data
             parentType, attrs = syntax
+            isTC = True
 
-        return parentType, attrs
+        return parentType, attrs, isTC
 
     # noinspection PyUnusedLocal,PyUnusedLocal,PyMethodMayBeStatic
     def gen_units(self, data, classmode=False):

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -229,7 +229,11 @@ class {{ symbol }}({{ definition['type']['type'] }}):
 {% for symbol, definition in mib.items() if definition['class'] == 'textualconvention' %}
 
 
-class {{ symbol }}({{ definition['type']['type'] }}, TextualConvention):
+    {% if definition['type']['tcbase'] %}
+class {{ symbol }}({{ definition['type']['type'] }}):
+    {% else %}
+class {{ symbol }}(TextualConvention, {{ definition['type']['type'] }}):
+    {% endif %}
     status = "{{ definition.get('status', 'current') }}"
     {% if 'displayhint' in definition %}
     displayHint = {{ definition['displayhint']|pythonstr }}

--- a/tests/test_imports_smiv2_pysnmp.py
+++ b/tests/test_imports_smiv2_pysnmp.py
@@ -134,7 +134,10 @@ class ImportTypeTestCase(unittest.TestCase):
         FROM SNMPv2-SMI
       TEXTUAL-CONVENTION
         FROM SNMPv2-TC
-      ImportedType1, Imported-Type-2, True
+      ImportedType1,
+      Imported-Type-2,
+      True,
+      ImportedType3
         FROM IMPORTED-MIB;
 
     testObject1 OBJECT-TYPE
@@ -142,6 +145,7 @@ class ImportTypeTestCase(unittest.TestCase):
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION "Test object"
+        DEFVAL      { '01020304'H }
       ::= { 1 3 }
 
     Test-Type-2 ::= TEXTUAL-CONVENTION
@@ -155,6 +159,7 @@ class ImportTypeTestCase(unittest.TestCase):
         MAX-ACCESS  read-only
         STATUS      current
         DESCRIPTION "Test object"
+        DEFVAL      { 'aabbccdd'H }
       ::= { 1 4 }
 
     False ::= TEXTUAL-CONVENTION
@@ -177,6 +182,20 @@ class ImportTypeTestCase(unittest.TestCase):
         DESCRIPTION "Test object"
       ::= { 1 6 }
 
+    TestType3 ::= TEXTUAL-CONVENTION
+        DISPLAY-HINT "2d:"
+        STATUS       current
+        DESCRIPTION  "Test TC"
+        SYNTAX       ImportedType3
+
+    testObject3 OBJECT-TYPE
+        SYNTAX      TestType3
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION "Test object"
+        DEFVAL      { '000100020003'H }
+      ::= { 1 7 }
+
     END
     """
 
@@ -189,7 +208,7 @@ class ImportTypeTestCase(unittest.TestCase):
         FROM SNMPv2-TC;
 
     ImportedType1 ::= TEXTUAL-CONVENTION
-        DISPLAY-HINT "255a"
+        DISPLAY-HINT "1d:"
         STATUS       current
         DESCRIPTION  "Test TC with display hint"
         SYNTAX       OCTET STRING
@@ -203,6 +222,8 @@ class ImportTypeTestCase(unittest.TestCase):
         STATUS       current
         DESCRIPTION  "Test TC"
         SYNTAX       OCTET STRING
+
+    ImportedType3 ::= OCTET STRING
 
     END
     """
@@ -230,8 +251,13 @@ class ImportTypeTestCase(unittest.TestCase):
     def testObjectTypeDisplayHint1(self):
         self.assertEqual(
             self.ctx["testObject1"].getSyntax().getDisplayHint(),
-            "255a",
+            "1d:",
             "bad display hint",
+        )
+
+    def testObjectTypePrettyValue1(self):
+        self.assertEqual(
+            self.ctx["testObject1"].getSyntax().prettyPrint(), "1:2:3:4", "bad defval"
         )
 
     def testObjectTypeName2(self):
@@ -247,6 +273,13 @@ class ImportTypeTestCase(unittest.TestCase):
             self.ctx["test_object_2"].getSyntax().getDisplayHint(),
             "1x:",
             "bad display hint",
+        )
+
+    def testObjectTypePrettyValue2(self):
+        self.assertEqual(
+            self.ctx["test_object_2"].getSyntax().prettyPrint(),
+            "aa:bb:cc:dd",
+            "bad defval",
         )
 
     def testObjectTypeNameReservedKeyword1(self):
@@ -273,6 +306,24 @@ class ImportTypeTestCase(unittest.TestCase):
             self.ctx["_pysmi_if"].getSyntax().getDisplayHint(),
             "2x:",
             "bad display hint",
+        )
+
+    def testObjectTypeName3(self):
+        self.assertEqual(self.ctx["testObject3"].getName(), (1, 7), "bad value")
+
+    def testObjectTypeLabel3(self):
+        self.assertEqual(self.ctx["testObject3"].getLabel(), "testObject3", "bad label")
+
+    def testObjectTypeDisplayHint3(self):
+        self.assertEqual(
+            self.ctx["testObject3"].getSyntax().getDisplayHint(),
+            "2d:",
+            "bad display hint",
+        )
+
+    def testObjectTypePrettyValue3(self):
+        self.assertEqual(
+            self.ctx["testObject3"].getSyntax().prettyPrint(), "1:2:3", "bad defval"
         )
 
 

--- a/tests/test_typedeclaration_smiv2_pysnmp.py
+++ b/tests/test_typedeclaration_smiv2_pysnmp.py
@@ -343,12 +343,12 @@ class TypeDeclarationInheritanceTestCase(unittest.TestCase):
     """
     TEST-MIB DEFINITIONS ::= BEGIN
     IMPORTS
-      Unsigned32
+      OBJECT-TYPE
         FROM SNMPv2-SMI
       TEXTUAL-CONVENTION
         FROM SNMPv2-TC;
 
-    TestTypeUnsigned32 ::= Unsigned32
+    TestTypeInteger ::= INTEGER
 
     --
     -- without constraints
@@ -359,14 +359,14 @@ class TypeDeclarationInheritanceTestCase(unittest.TestCase):
         DISPLAY-HINT "d-1"
         STATUS       current
         DESCRIPTION  "Test TC 1"
-        SYNTAX       Unsigned32
+        SYNTAX       INTEGER
 
     -- textual convention for simple type, derived from base type
     TestTC-SB ::= TEXTUAL-CONVENTION
         DISPLAY-HINT "d-2"
         STATUS       current
         DESCRIPTION  "Test TC 2"
-        SYNTAX       TestTypeUnsigned32
+        SYNTAX       TestTypeInteger
 
     -- textual convention for textual convention, derived from base type
     TestTC-TB ::= TEXTUAL-CONVENTION
@@ -430,6 +430,50 @@ class TypeDeclarationInheritanceTestCase(unittest.TestCase):
         STATUS       current
         DESCRIPTION  "Test TC 10"
         SYNTAX       TestTC-TC (SIZE (20..23))
+
+    --
+    -- test objects (without constraints only)
+    --
+
+    testObjectB OBJECT-TYPE
+        SYNTAX       TestTC-B
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+        DEFVAL       { 123456 }
+      ::= { 1 4 1 }
+
+    testObjectSB OBJECT-TYPE
+        SYNTAX       TestTC-SB
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+        DEFVAL       { 123456 }
+      ::= { 1 4 2 }
+
+    testObjectTB OBJECT-TYPE
+        SYNTAX       TestTC-TB
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+        DEFVAL       { 123456 }
+      ::= { 1 4 3 }
+
+    testObjectTSB OBJECT-TYPE
+        SYNTAX       TestTC-TSB
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+        DEFVAL       { 123456 }
+      ::= { 1 4 4 }
+
+    testObjectTTB OBJECT-TYPE
+        SYNTAX       TestTC-TTB
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+        DEFVAL       { 123456 }
+      ::= { 1 4 5 }
 
     END
     """
@@ -549,6 +593,31 @@ class TypeDeclarationInheritanceTestCase(unittest.TestCase):
             self.ctx["TestTC_TTC"]().getDisplayHint(),
             "1x:",
             "bad DISPLAY-HINT",
+        )
+
+    def testObjectTypePrettyValueB(self):
+        self.assertEqual(
+            self.ctx["testObjectB"].getSyntax().prettyPrint(), "12345.6", "bad DEFVAL"
+        )
+
+    def testObjectTypePrettyValueSB(self):
+        self.assertEqual(
+            self.ctx["testObjectSB"].getSyntax().prettyPrint(), "1234.56", "bad DEFVAL"
+        )
+
+    def testObjectTypePrettyValueTB(self):
+        self.assertEqual(
+            self.ctx["testObjectTB"].getSyntax().prettyPrint(), "123.456", "bad DEFVAL"
+        )
+
+    def testObjectTypePrettyValueTSB(self):
+        self.assertEqual(
+            self.ctx["testObjectTSB"].getSyntax().prettyPrint(), "12.3456", "bad DEFVAL"
+        )
+
+    def testObjectTypePrettyValueTTB(self):
+        self.assertEqual(
+            self.ctx["testObjectTTB"].getSyntax().prettyPrint(), "1.23456", "bad DEFVAL"
         )
 
 


### PR DESCRIPTION
This change restores support in pysmi for *applying* display hints, as was broken by lextudio/pysmi@84be3ff. This is the pysmi issue I mentioned in lextudio/pysnmp#139. Of course, the display hint related issues in pysnmp itself still remain.

As before, this change has been tested with the script from PR #3, now with the updated mibs.pysnmp.com collection. The results are exactly the same before and after this change. From pysmi's perspective, the main observable difference of this change is that the newly added "PrettyValue" test cases failed before, and pass after this change.

Please note that when using the latest pysnmp HEAD, the pysmi test set already started to fail for other reasons (namely, the rename of namedValues). I don't know whether that will be an issue for automatic verification here.

Also, a heads-up FWIW: I intend to submit a few more pysmi changes later this week, with as ultimate goal the ability to regenerate the code of the base MIBs in pysnmp.