### PR TITLE
Fixes to allow for regeneration of pysnmp base MIBs

### DIFF
--- a/pysmi/codegen/base.py
+++ b/pysmi/codegen/base.py
@@ -316,6 +316,15 @@ class AbstractCodeGen:
 
     @staticmethod
     def trans_opers(symbol):
+        """Convert an ASN.1 name to a "Pythonized" symbol.
+
+        The resulting symbol must be usable as a name in Python code. As such,
+        dashes are replaced with underscores, and reserved Python keywords are
+        prefixed so as to make them usable as regular identifier names.
+
+        Calling this function on a symbol that is already "Pythonized", has no
+        effect, but should be avoided in general anyway.
+        """
         if iskeyword(symbol):
             symbol = RESERVED_KEYWORDS_PREFIX + symbol
         return symbol.replace("-", "_")

--- a/pysmi/codegen/intermediate.py
+++ b/pysmi/codegen/intermediate.py
@@ -734,15 +734,22 @@ class IntermediateCodeGen(AbstractCodeGen):
             elif defvalType[0][0] in ("Integer32", "Integer") and isinstance(
                 defvalType[1], list
             ):
+                # For enumerations, the ASN.1 DEFVAL statements contain names,
+                # whereas the code generation template expects integer values
+                # (represented as strings).
+                nameToValueMap = dict(defvalType[1])
+
                 # buggy MIB: DEFVAL { { ... } }
                 if isinstance(defval, list):
-                    defval = [dv for dv in defval if dv in dict(defvalType[1])]
+                    defval = [dv for dv in defval if dv in nameToValueMap]
                     if defval:
-                        outDict.update(value=defval[0], format="enum")
+                        outDict.update(
+                            value=str(nameToValueMap[defval[0]]), format="enum"
+                        )
 
                 # good MIB: DEFVAL { ... }
-                elif defval in dict(defvalType[1]):
-                    outDict.update(value=defval, format="enum")
+                elif defval in nameToValueMap:
+                    outDict.update(value=str(nameToValueMap[defval]), format="enum")
 
             elif defvalType[0][0] == "Bits":
                 defvalBits = []

--- a/pysmi/codegen/symtable.py
+++ b/pysmi/codegen/symtable.py
@@ -77,8 +77,8 @@ class SymtableCodeGen(AbstractCodeGen):
     }
 
     def __init__(self):
-        self._rows = set()
-        self._cols = {}  # k, v = name, datatype
+        self._rows = set()  # symbols
+        self._cols = {}  # k, v = name, datatype [name is *not* a Pythonized symbol!]
         self._sequenceTypes = set()
         self._exports = set()
         self._postponedSyms = {}  # k, v = symbol, (parents, properties)
@@ -394,7 +394,7 @@ class SymtableCodeGen(AbstractCodeGen):
     def gen_conceptual_table(self, data, classmode=False):
         row = data[0]
         if row[0] and row[0][0]:
-            self._rows.add(self.trans_opers(row[0][0]))
+            self._rows.add(row[0][0])  # (already a Pythonized symbol)
         return ("MibTable", ""), ""
 
     # noinspection PyUnusedLocal,PyUnusedLocal,PyMethodMayBeStatic

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -514,9 +514,9 @@ if mibBuilder.loadTexts:
 {{ symbol }} = ModuleCompliance(
     {{ definition['oid'] }}
 )
-    {% if 'objects' in definition %}
+    {% if 'modulecompliance' in definition %}
 {{ symbol }}.setObjects(
-    {% for obj in definition['objects'] %}
+    {% for obj in definition['modulecompliance'] %}
         {% if loop.first and loop.last %}
     ("{{ obj['module'] }}", "{{  obj['object'] }}")
         {% elif loop.first %}

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -364,7 +364,7 @@ if mibBuilder.loadTexts:
    and 'augmention' in definition %}
 {{ definition['augmention']['object'] }}.registerAugmentions(
     ("{{ mib['meta']['module'] }}",
-     "{{ symbol }}")
+     "{{ definition['name'] }}")
 )
 {{ symbol }}.setIndexNames(*{{ definition['augmention']['object'] }}.getIndexNames())
 {% endfor %}

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -190,12 +190,8 @@ if mibBuilder.loadTexts:
     {% elif definition['default']['default']['format'] == 'string' %}
     {# TODO: pyasn1 does not like defaulted strings #}
     defaultValue = OctetString({{ definition['default']['default']['value']|pythonstr }})
-    {% elif definition['default']['default']['format'] == 'oid' %}
+    {% elif definition['default']['default']['format'] in ('oid', 'enum') %}
     defaultValue = {{ definition['default']['default']['value'] }}
-    {% elif definition['default']['default']['format'] == 'enum'
-        and 'constraints' in definition['syntax'] %}
-    {# TODO: pyasn1 does not like default enum #}
-    defaultValue = {{ definition['syntax']['constraints']['enumeration'][definition['default']['default']['value']] }}
     {% elif definition['default']['default']['format'] == 'bits' %}
     {# TODO: pyasn1 does not like default named bits #}
     defaultBinValue = "{{ definition['default']['default']['value']['bits'].values()|bitstring }}"

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -73,7 +73,8 @@ Managed Objects Instances.
     {{ definition['oid'] }}
 )
     {% if 'revisions' in definition %}
-{{ symbol }}.setRevisions(
+if mibBuilder.loadTexts:
+    {{ symbol }}.setRevisions(
         {% for revision in definition.get('revisions', ()) %}
             {% if loop.first and loop.last %}
         ({{ revision['revision']|pythonstr }},)
@@ -85,17 +86,19 @@ Managed Objects Instances.
          {{ revision['revision']|pythonstr }},
             {%  endif %}
         {%  endfor %}
-)
+    )
     {% endif %}
     {% if 'lastupdated' in definition %}
-{{ symbol }}.setLastUpdated({{ definition['lastupdated']|pythonstr }})
+if mibBuilder.loadTexts:
+    {{ symbol }}.setLastUpdated({{ definition['lastupdated']|pythonstr }})
     {% endif %}
     {% if 'organization' in definition %}
 if mibBuilder.loadTexts:
     {{ symbol }}.setOrganization({{ definition['organization']|pythonstr }})
     {% endif %}
     {% if 'contactinfo' in definition %}
-{{ symbol }}.setContactInfo({{ definition['contactinfo']|pythonstr }})
+if mibBuilder.loadTexts:
+    {{ symbol }}.setContactInfo({{ definition['contactinfo']|pythonstr }})
     {% endif %}
     {% if 'description' in definition %}
 if mibBuilder.loadTexts:

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -22,16 +22,16 @@ Managed Objects Instances.
 
 {% block asn1_constraints_imports scoped %}
 (ConstraintsIntersection,
+ ConstraintsUnion,
  SingleValueConstraint,
  ValueRangeConstraint,
- ValueSizeConstraint,
- ConstraintsUnion) = mibBuilder.importSymbols(
+ ValueSizeConstraint) = mibBuilder.importSymbols(
     "ASN1-REFINEMENT",
     "ConstraintsIntersection",
+    "ConstraintsUnion",
     "SingleValueConstraint",
     "ValueRangeConstraint",
-    "ValueSizeConstraint",
-    "ConstraintsUnion")
+    "ValueSizeConstraint")
 {% endblock -%}
 
 {% block smi_imports scoped %}
@@ -127,7 +127,7 @@ if mibBuilder.loadTexts:
         )
     )
     namedValues = NamedValues(
-    {% for name, iden in spec['enumeration'].items()|sort %}
+    {% for name, iden in spec['enumeration'].items()|sort(attribute='1') %}
         {% if loop.first and loop.last %}
         ("{{ name}}", {{ iden }})
         {% elif loop.first %}
@@ -156,7 +156,7 @@ if mibBuilder.loadTexts:
 
 {% macro bits(namedbits) %}
     namedValues = NamedValues(
-    {% for name, iden in namedbits.items()|sort %}
+    {% for name, iden in namedbits.items()|sort(attribute='1') %}
         {% if loop.first and loop.last %}
         ("{{ name}}", {{ iden }})
         {% elif loop.first %}

--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -278,9 +278,7 @@ class _{{ symbol|capfirst }}_Type({{ definition['syntax']['type'] }}):
 {{ bits(definition['syntax']['bits']) }}
                 {% endif %}
 
-                {% if 'constraints' in definition['syntax'] or 'bits' in definition['syntax'] %}
 _{{ symbol|capfirst }}_Type.__name__ = "{{ definition['syntax']['type'] }}"
-                {% endif %}
             {% else %}
 _{{ symbol|capfirst }}_Type = {{ definition['syntax']['type'] }}
             {% endif %}

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -24,7 +24,7 @@ suite = unittest.TestLoader().loadTestsFromNames(
         "test_objecttype_smiv1_pysnmp",
         "test_objecttype_smiv2_pysnmp",
         "test_smiv1_smiv2_pysnmp",
-        "test_traptype_smiv2_pysnmp",
+        "test_traptype_smiv1_pysnmp",
         "test_typedeclaration_smiv1_pysnmp",
         "test_typedeclaration_smiv2_pysnmp",
         "test_valuedeclaration_smiv2_pysnmp",

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -24,6 +24,7 @@ suite = unittest.TestLoader().loadTestsFromNames(
         "test_objecttype_smiv1_pysnmp",
         "test_objecttype_smiv2_pysnmp",
         "test_smiv1_smiv2_pysnmp",
+        "test_syntaxname_smiv2_pysnmp",
         "test_traptype_smiv1_pysnmp",
         "test_typedeclaration_smiv1_pysnmp",
         "test_typedeclaration_smiv2_pysnmp",

--- a/tests/test_agentcapabilities_smiv2_pysnmp.py
+++ b/tests/test_agentcapabilities_smiv2_pysnmp.py
@@ -33,6 +33,7 @@ class AgentCapabilitiesTestCase(unittest.TestCase):
         STATUS          current
         DESCRIPTION
             "test capabilities"
+        REFERENCE       "test reference"
 
         SUPPORTS        TEST-MIB
         INCLUDES        {
@@ -76,11 +77,23 @@ class AgentCapabilitiesTestCase(unittest.TestCase):
     def testAgentCapabilitiesName(self):
         self.assertEqual(self.ctx["testCapability"].getName(), (1, 3), "bad name")
 
+    def testAgentCapabilitiesStatus(self):
+        self.assertEqual(
+            self.ctx["testCapability"].getStatus(), "current", "bad STATUS"
+        )
+
     def testAgentCapabilitiesDescription(self):
         self.assertEqual(
             self.ctx["testCapability"].getDescription(),
             "test capabilities",
             "bad DESCRIPTION",
+        )
+
+    def testAgentCapabilitiesReference(self):
+        self.assertEqual(
+            self.ctx["testCapability"].getReference(),
+            "test reference",
+            "bad REFERENCE",
         )
 
     # XXX SUPPORTS/INCLUDES/VARIATION/ACCESS not supported by pysnmp
@@ -142,10 +155,12 @@ class AgentCapabilitiesTextTestCase(unittest.TestCase):
     testCapability AGENT-CAPABILITIES
         PRODUCT-RELEASE "Test product
     Version 1.0 \\ 2024-08-20"
-        STATUS          current
+        STATUS          obsolete
         DESCRIPTION
     "test \\ncapabilities
     \\"
+        REFERENCE       "test
+    reference"
 
      ::= { 1 3 }
 
@@ -171,6 +186,13 @@ class AgentCapabilitiesTextTestCase(unittest.TestCase):
 
         exec(codeobj, self.ctx, self.ctx)
 
+    def testAgentCapabilitiesStatus(self):
+        # Use a value other than "current" in this test, as "current" is the
+        # default pysnmp value (which could mean the test value was never set).
+        self.assertEqual(
+            self.ctx["testCapability"].getStatus(), "obsolete", "bad STATUS"
+        )
+
     def testAgentCapabilitiesProductRelease(self):
         self.assertEqual(
             self.ctx["testCapability"].getProductRelease(),
@@ -183,6 +205,77 @@ class AgentCapabilitiesTextTestCase(unittest.TestCase):
             self.ctx["testCapability"].getDescription(),
             "test \\ncapabilities\n\\",
             "bad DESCRIPTION",
+        )
+
+    def testAgentCapabilitiesReference(self):
+        self.assertEqual(
+            self.ctx["testCapability"].getReference(),
+            "test\nreference",
+            "bad REFERENCE",
+        )
+
+
+class AgentCapabilitiesNoLoadTextsTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+        MODULE-IDENTITY
+            FROM SNMPv2-SMI
+        AGENT-CAPABILITIES
+            FROM SNMPv2-CONF;
+
+    testCapability AGENT-CAPABILITIES
+        PRODUCT-RELEASE "Test product"
+        STATUS          deprecated
+        DESCRIPTION
+            "test capabilities"
+        REFERENCE       "test reference"
+
+        SUPPORTS        TEST-MIB
+        INCLUDES        {
+                            testSystemGroup
+                        }
+        VARIATION       testSysLevelType
+        ACCESS          read-only
+        DESCRIPTION
+            "Not supported."
+
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().gen_code(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().gen_code(
+            ast, {mibInfo.name: symtable}, genTexts=True
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testAgentCapabilitiesStatus(self):
+        # "current" is the default pysnmp value, and therefore what we get if
+        # we request that texts not be loaded.
+        self.assertEqual(
+            self.ctx["testCapability"].getStatus(), "current", "bad STATUS"
+        )
+
+    def testAgentCapabilitiesDescription(self):
+        self.assertEqual(
+            self.ctx["testCapability"].getDescription(),
+            "",
+            "bad DESCRIPTION",
+        )
+
+    def testAgentCapabilitiesReference(self):
+        self.assertEqual(
+            self.ctx["testCapability"].getReference(),
+            "",
+            "bad REFERENCE",
         )
 
 

--- a/tests/test_imports_smiv2_pysnmp.py
+++ b/tests/test_imports_smiv2_pysnmp.py
@@ -389,6 +389,401 @@ class ImportTCEnumUsedByDefvalTestCase(unittest.TestCase):
         self.assertEqual(self.ctx["testObject"].getSyntax(), 1, "bad DEFVAL")
 
 
+class ImportObjectsTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-TYPE, NOTIFICATION-TYPE
+        FROM SNMPv2-SMI
+      OBJECT-GROUP, NOTIFICATION-GROUP, MODULE-COMPLIANCE
+        FROM SNMPv2-CONF
+      -- For the purpose of this test, the types of these symbols do not matter.
+      importedValue1, imported-value-2, global
+        FROM IMPORTED-MIB;
+
+    testNotificationType NOTIFICATION-TYPE
+        OBJECTS         {
+                            importedValue1,
+                            imported-value-2,
+                            global
+                        }
+        STATUS          current
+        DESCRIPTION     "A collection of test notification types."
+      ::= { 1 6 }
+
+    testObjectGroup OBJECT-GROUP
+        OBJECTS         {
+                            importedValue1,
+                            imported-value-2,
+                            global
+                        }
+        STATUS          current
+        DESCRIPTION     "A collection of test objects."
+      ::= { 1 7 }
+
+    testNotificationGroup NOTIFICATION-GROUP
+        NOTIFICATIONS   {
+                            importedValue1,
+                            imported-value-2,
+                            global
+                        }
+        STATUS          current
+        DESCRIPTION     "A collection of test notifications."
+      ::= { 1 8 }
+
+    testModuleCompliance MODULE-COMPLIANCE
+        STATUS        current
+        DESCRIPTION   "This is the MIB compliance statement"
+        MODULE        IMPORTED-MIB
+        MANDATORY-GROUPS {
+            importedValue1,
+            imported-value-2,
+            nonexistentValue
+        }
+        GROUP        global
+        DESCRIPTION  "Support for these notifications is optional."
+      ::= { 1 9 }
+
+    END
+    """
+
+    IMPORTED_MIB = """
+    IMPORTED-MIB DEFINITIONS ::= BEGIN
+
+    importedValue1    OBJECT IDENTIFIER ::= { 1 3 }
+    imported-value-2  OBJECT IDENTIFIER ::= { 1 4 }
+    global            OBJECT IDENTIFIER ::= { 1 5 }  -- a reserved Python keyword
+
+    END
+    """
+
+    def setUp(self):
+        self.ctx = {"mibBuilder": MibBuilder()}
+        symbolTable = {}
+
+        for mibData in (self.IMPORTED_MIB, self.__class__.__doc__):
+            ast = parserFactory()().parse(mibData)[0]
+            mibInfo, symtable = SymtableCodeGen().gen_code(ast, {})
+
+            symbolTable[mibInfo.name] = symtable
+
+            mibInfo, pycode = PySnmpCodeGen().gen_code(ast, dict(symbolTable))
+            codeobj = compile(pycode, "test", "exec")
+            exec(codeobj, self.ctx, self.ctx)
+
+    def testNotificationTypeObjects(self):
+        self.assertEqual(
+            self.ctx["testNotificationType"].getObjects(),
+            (
+                ("IMPORTED-MIB", "importedValue1"),
+                ("IMPORTED-MIB", "imported-value-2"),
+                ("IMPORTED-MIB", "global"),
+            ),
+            "bad OBJECTS",
+        )
+
+    def testObjectGroupObjects(self):
+        self.assertEqual(
+            self.ctx["testObjectGroup"].getObjects(),
+            (
+                ("IMPORTED-MIB", "importedValue1"),
+                ("IMPORTED-MIB", "imported-value-2"),
+                ("IMPORTED-MIB", "global"),
+            ),
+            "bad OBJECTS",
+        )
+
+    def testNotificationGroupObjects(self):
+        self.assertEqual(
+            self.ctx["testNotificationGroup"].getObjects(),
+            (
+                ("IMPORTED-MIB", "importedValue1"),
+                ("IMPORTED-MIB", "imported-value-2"),
+                ("IMPORTED-MIB", "global"),
+            ),
+            "bad OBJECTS",
+        )
+
+    def testModuleComplianceObjects(self):
+        self.assertEqual(
+            self.ctx["testModuleCompliance"].getObjects(),
+            (
+                ("IMPORTED-MIB", "importedValue1"),
+                ("IMPORTED-MIB", "imported-value-2"),
+                # Even if the referenced MIB does not export the value, the
+                # resulting object must still consist of the correct MIB and
+                # object name.
+                ("IMPORTED-MIB", "nonexistentValue"),
+                ("IMPORTED-MIB", "global"),
+            ),
+            "bad OBJECTS",
+        )
+
+
+class ImportObjectIdentifierDefaultTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-TYPE
+        FROM SNMPv2-SMI
+      importedValue1, imported-value-2, global
+        FROM IMPORTED-MIB;
+
+    testObject1 OBJECT-TYPE
+        SYNTAX      OBJECT IDENTIFIER
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION "Test object"
+        DEFVAL      { importedValue1 }
+      ::= { 1 6 }
+
+    testObject2 OBJECT-TYPE
+        SYNTAX      OBJECT IDENTIFIER
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION "Test object"
+        DEFVAL      { imported-value-2 }
+      ::= { 1 7 }
+
+    testObject3 OBJECT-TYPE
+        SYNTAX      OBJECT IDENTIFIER
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION "Test object"
+        DEFVAL      { global }
+      ::= { 1 8 }
+
+    END
+    """
+
+    IMPORTED_MIB = """
+    IMPORTED-MIB DEFINITIONS ::= BEGIN
+
+    importedValue1    OBJECT IDENTIFIER ::= { 1 3 }
+    imported-value-2  OBJECT IDENTIFIER ::= { 1 4 }
+    global            OBJECT IDENTIFIER ::= { 1 5 }  -- a reserved Python keyword
+
+    END
+    """
+
+    def setUp(self):
+        self.ctx = {"mibBuilder": MibBuilder()}
+        symbolTable = {}
+
+        for mibData in (self.IMPORTED_MIB, self.__class__.__doc__):
+            ast = parserFactory()().parse(mibData)[0]
+            mibInfo, symtable = SymtableCodeGen().gen_code(ast, {})
+
+            symbolTable[mibInfo.name] = symtable
+
+            mibInfo, pycode = PySnmpCodeGen().gen_code(ast, dict(symbolTable))
+            codeobj = compile(pycode, "test", "exec")
+            exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectTypeSyntax1(self):
+        self.assertEqual(
+            self.ctx["testObject1"].getSyntax(),
+            (1, 3),
+            "bad DEFVAL",
+        )
+
+    def testObjectTypeSyntax2(self):
+        self.assertEqual(
+            self.ctx["testObject2"].getSyntax(),
+            (1, 4),
+            "bad DEFVAL",
+        )
+
+    def testObjectTypeSyntax3(self):
+        self.assertEqual(
+            self.ctx["testObject3"].getSyntax(),
+            (1, 5),
+            "bad DEFVAL",
+        )
+
+
+class ImportMibTableHyphenTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-TYPE
+        FROM SNMPv2-SMI
+      test-entry, testIndex1, test-index-2, global
+        FROM IMPORTED-MIB;
+
+    --
+    -- Augmentation
+    --
+
+    testTableAug OBJECT-TYPE
+        SYNTAX          SEQUENCE OF TestEntryAug
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "Test table"
+      ::= { 1 4 }
+
+    test-entry-aug OBJECT-TYPE
+        SYNTAX          TestEntryAug
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "Test row"
+        AUGMENTS        { test-entry }
+      ::= { testTableAug 1 }
+
+    TestEntryAug ::= SEQUENCE {
+        testIndexAug    INTEGER
+    }
+
+    testIndexAug OBJECT-TYPE
+        SYNTAX          INTEGER
+        MAX-ACCESS      read-create
+        STATUS          current
+        DESCRIPTION     "Test column"
+      ::= { test-entry-aug 1 }
+
+    --
+    -- External indices
+    --
+
+    testTableExt OBJECT-TYPE
+        SYNTAX          SEQUENCE OF TestEntryExt
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "Test table"
+      ::= { 1 5 }
+
+    testEntryExt OBJECT-TYPE
+        SYNTAX          TestEntryExt
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "Test row"
+        INDEX           { testIndex1, test-index-2, global }
+      ::= { testTableExt 1 }
+
+    TestEntryExt ::= SEQUENCE {
+        testColumn      OCTET STRING
+    }
+
+    testColumn OBJECT-TYPE
+        SYNTAX          OCTET STRING
+        MAX-ACCESS      read-create
+        STATUS          current
+        DESCRIPTION     "Test column"
+      ::= { testEntryExt 1 }
+
+    END
+    """
+
+    IMPORTED_MIB = """
+    IMPORTED-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-TYPE
+        FROM SNMPv2-SMI;
+
+    testTable OBJECT-TYPE
+        SYNTAX          SEQUENCE OF TestEntry
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "Test table"
+      ::= { 1 3 }
+
+    test-entry OBJECT-TYPE
+        SYNTAX          TestEntry
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "Test row"
+        INDEX           { testIndex1, test-index-2, global }
+      ::= { testTable 1 }
+
+    TestEntry ::= SEQUENCE {
+        testIndex1      INTEGER,
+        test-index-2    INTEGER,
+        global          OCTET STRING,
+        testColumn      INTEGER
+    }
+
+    testIndex1 OBJECT-TYPE
+        SYNTAX          INTEGER
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "Test column"
+      ::= { test-entry 1 }
+
+    test-index-2 OBJECT-TYPE
+        SYNTAX          INTEGER
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "Test column"
+      ::= { test-entry 2 }
+
+    global OBJECT-TYPE
+        SYNTAX          OCTET STRING
+        MAX-ACCESS      not-accessible
+        STATUS          current
+        DESCRIPTION     "Test column"
+      ::= { test-entry 3 }
+
+    testColumn OBJECT-TYPE
+        SYNTAX          INTEGER
+        MAX-ACCESS      read-write
+        STATUS          current
+        DESCRIPTION     "Test column"
+      ::= { test-entry 4 }
+
+    END
+    """
+
+    def setUp(self):
+        self.ctx = {"mibBuilder": MibBuilder()}
+        symbolTable = {}
+
+        for mibData in (self.IMPORTED_MIB, self.__class__.__doc__):
+            ast = parserFactory()().parse(mibData)[0]
+            mibInfo, symtable = SymtableCodeGen().gen_code(ast, {})
+
+            symbolTable[mibInfo.name] = symtable
+
+            mibInfo, pycode = PySnmpCodeGen().gen_code(ast, dict(symbolTable))
+            codeobj = compile(pycode, "test", "exec")
+            exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectTypeTableRowAugmentation(self):
+        # TODO: provide getAugmentation() method
+        try:
+            augmentingRows = self.ctx["test_entry"].augmentingRows
+
+        except AttributeError:
+            augmentingRows = self.ctx["test_entry"]._augmentingRows
+
+        self.assertEqual(
+            list(augmentingRows)[0],
+            ("TEST-MIB", "test-entry-aug"),
+            "bad AUGMENTS table clause",
+        )
+
+    def testObjectTypeTableAugRowIndex(self):
+        self.assertEqual(
+            self.ctx["test_entry_aug"].getIndexNames(),
+            (
+                (0, "IMPORTED-MIB", "testIndex1"),
+                (0, "IMPORTED-MIB", "test-index-2"),
+                (0, "IMPORTED-MIB", "global"),
+            ),
+            "bad table indices",
+        )
+
+    def testObjectTypeTableExtRowIndex(self):
+        self.assertEqual(
+            self.ctx["testEntryExt"].getIndexNames(),
+            (
+                (0, "IMPORTED-MIB", "testIndex1"),
+                (0, "IMPORTED-MIB", "test-index-2"),
+                (0, "IMPORTED-MIB", "global"),
+            ),
+            "bad table indices",
+        )
+
+
 class ImportSelfTestCase(unittest.TestCase):
     """
     Test-MIB DEFINITIONS ::= BEGIN

--- a/tests/test_modulecompliance_smiv2_pysnmp.py
+++ b/tests/test_modulecompliance_smiv2_pysnmp.py
@@ -77,6 +77,17 @@ class ModuleComplianceTestCase(unittest.TestCase):
             "bad DESCRIPTION",
         )
 
+    def testModuleComplianceObjects(self):
+        self.assertEqual(
+            self.ctx["testCompliance"].getObjects(),
+            (
+                ("TEST-MIB", "testComplianceInfoGroup"),
+                ("TEST-MIB", "testNotificationInfoGroup"),
+                ("TEST-MIB", "testNotificationGroup"),
+            ),
+            "bad OBJECTS",
+        )
+
     def testModuleComplianceClass(self):
         self.assertEqual(
             self.ctx["testCompliance"].__class__.__name__,

--- a/tests/test_modulecompliance_smiv2_pysnmp.py
+++ b/tests/test_modulecompliance_smiv2_pysnmp.py
@@ -5,6 +5,7 @@
 # License: https://www.pysnmp.com/pysmi/license.html
 #
 import sys
+import textwrap
 
 try:
     import unittest2 as unittest
@@ -62,6 +63,13 @@ class ModuleComplianceTestCase(unittest.TestCase):
     def testModuleComplianceName(self):
         self.assertEqual(self.ctx["testCompliance"].getName(), (1, 3), "bad name")
 
+    def testModuleComplianceStatus(self):
+        self.assertEqual(
+            self.ctx["testCompliance"].getStatus(),
+            "current",
+            "bad STATUS",
+        )
+
     def testModuleComplianceDescription(self):
         self.assertEqual(
             self.ctx["testCompliance"].getDescription(),
@@ -116,6 +124,118 @@ class ModuleComplianceHyphenTestCase(unittest.TestCase):
     def testModuleComplianceLabel(self):
         self.assertEqual(
             self.ctx["test_compliance"].getLabel(), "test-compliance", "bad label"
+        )
+
+
+class ModuleComplianceTextTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      MODULE-COMPLIANCE
+        FROM SNMPv2-CONF;
+
+    testCompliance MODULE-COMPLIANCE
+     STATUS      deprecated
+     DESCRIPTION  "This is the MIB
+      compliance statement\\"
+     MODULE
+      MANDATORY-GROUPS {
+       testComplianceInfoGroup,
+       testNotificationInfoGroup
+      }
+      GROUP     testNotificationGroup
+      DESCRIPTION
+            "Support for these notifications is optional."
+      ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        docstring = textwrap.dedent(self.__class__.__doc__)
+        ast = parserFactory()().parse(docstring)[0]
+        mibInfo, symtable = SymtableCodeGen().gen_code(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().gen_code(
+            ast,
+            {mibInfo.name: symtable},
+            genTexts=True,
+            textFilter=lambda symbol, text: text,
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        mibBuilder = MibBuilder()
+        mibBuilder.loadTexts = True
+
+        self.ctx = {"mibBuilder": mibBuilder}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testModuleComplianceStatus(self):
+        # Use a value other than "current" in this test, as "current" is the
+        # default pysnmp value (which could mean the test value was never set).
+        self.assertEqual(
+            self.ctx["testCompliance"].getStatus(),
+            "deprecated",
+            "bad STATUS",
+        )
+
+    def testModuleComplianceDescription(self):
+        self.assertEqual(
+            self.ctx["testCompliance"].getDescription(),
+            "This is the MIB\n  compliance statement\\",
+            "bad DESCRIPTION",
+        )
+
+
+class ModuleComplianceNoLoadTextsTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      MODULE-COMPLIANCE
+        FROM SNMPv2-CONF;
+
+    testCompliance MODULE-COMPLIANCE
+     STATUS      obsolete
+     DESCRIPTION  "This is the MIB compliance statement"
+     MODULE
+      MANDATORY-GROUPS {
+       testComplianceInfoGroup,
+       testNotificationInfoGroup
+      }
+      GROUP     testNotificationGroup
+      DESCRIPTION
+            "Support for these notifications is optional."
+      ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().gen_code(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().gen_code(
+            ast, {mibInfo.name: symtable}, genTexts=True
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testModuleComplianceStatus(self):
+        # "current" is the default pysnmp value, and therefore what we get if
+        # we request that texts not be loaded.
+        self.assertEqual(
+            self.ctx["testCompliance"].getStatus(),
+            "current",
+            "bad STATUS",
+        )
+
+    def testModuleComplianceDescription(self):
+        self.assertEqual(
+            self.ctx["testCompliance"].getDescription(),
+            "",
+            "bad DESCRIPTION",
         )
 
 

--- a/tests/test_modulecompliance_smiv2_pysnmp.py
+++ b/tests/test_modulecompliance_smiv2_pysnmp.py
@@ -108,10 +108,10 @@ class ModuleComplianceHyphenTestCase(unittest.TestCase):
      DESCRIPTION  "This is the MIB compliance statement"
      MODULE
       MANDATORY-GROUPS {
-       testComplianceInfoGroup,
-       testNotificationInfoGroup
+       test-compliance-info-group,
+       if                           -- a reserved Python keyword
       }
-      GROUP     testNotificationGroup
+      GROUP     test-notification-group
       DESCRIPTION
             "Support for these notifications is optional."
       ::= { 1 3 }
@@ -135,6 +135,17 @@ class ModuleComplianceHyphenTestCase(unittest.TestCase):
     def testModuleComplianceLabel(self):
         self.assertEqual(
             self.ctx["test_compliance"].getLabel(), "test-compliance", "bad label"
+        )
+
+    def testModuleComplianceObjects(self):
+        self.assertEqual(
+            self.ctx["test_compliance"].getObjects(),
+            (
+                ("TEST-MIB", "test-compliance-info-group"),
+                ("TEST-MIB", "if"),
+                ("TEST-MIB", "test-notification-group"),
+            ),
+            "bad OBJECTS",
         )
 
 

--- a/tests/test_moduleidentity_smiv2_pysnmp.py
+++ b/tests/test_moduleidentity_smiv2_pysnmp.py
@@ -213,6 +213,71 @@ class ModuleIdentityTextTestCase(unittest.TestCase):
         )
 
 
+class ModuleIdentityNoLoadTextsTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+     MODULE-IDENTITY
+        FROM SNMPv2-SMI;
+
+    testModule MODULE-IDENTITY
+     LAST-UPDATED "200001100000Z" -- Midnight 10 January 2000
+     ORGANIZATION "AgentX Working Group"
+     CONTACT-INFO "WG-email:   agentx@dorothy.bmc.com"
+     DESCRIPTION  "This is the MIB module for the SNMP"
+     REVISION     "200001100000Z" -- Midnight 10 January 2000
+     DESCRIPTION  "Initial version published as RFC 2742."
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().gen_code(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().gen_code(
+            ast, {mibInfo.name: symtable}, genTexts=True
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testModuleIdentityLastUpdated(self):
+        self.assertEqual(
+            self.ctx["testModule"].getLastUpdated(), "", "bad LAST-UPDATED"
+        )
+
+    def testModuleIdentityOrganization(self):
+        self.assertEqual(
+            self.ctx["testModule"].getOrganization(),
+            "",
+            "bad ORGANIZATION",
+        )
+
+    def testModuleIdentityRevisions(self):
+        self.assertEqual(
+            self.ctx["testModule"].getRevisions(),
+            (),
+            "bad REVISIONS",
+        )
+
+    def testModuleIdentityContactInfo(self):
+        self.assertEqual(
+            self.ctx["testModule"].getContactInfo(),
+            "",
+            "bad CONTACT-INFO",
+        )
+
+    def testModuleIdentityDescription(self):
+        self.assertEqual(
+            self.ctx["testModule"].getDescription(),
+            "",
+            "bad DESCRIPTION",
+        )
+
+
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
 
 if __name__ == "__main__":

--- a/tests/test_notificationgroup_smiv2_pysnmp.py
+++ b/tests/test_notificationgroup_smiv2_pysnmp.py
@@ -5,6 +5,7 @@
 # License: https://www.pysnmp.com/pysmi/license.html
 #
 import sys
+import textwrap
 
 try:
     import unittest2 as unittest
@@ -62,6 +63,13 @@ class NotificationGroupTestCase(unittest.TestCase):
             self.ctx["testNotificationGroup"].getName(), (1, 3), "bad name"
         )
 
+    def testNotificationGroupStatus(self):
+        self.assertEqual(
+            self.ctx["testNotificationGroup"].getStatus(),
+            "current",
+            "bad STATUS",
+        )
+
     def testNotificationGroupDescription(self):
         self.assertEqual(
             self.ctx["testNotificationGroup"].getDescription(),
@@ -114,6 +122,113 @@ class NotificationGroupHyphenTestCase(unittest.TestCase):
             self.ctx["test_notification_group"].getLabel(),
             "test-notification-group",
             "bad label",
+        )
+
+
+class NotificationGroupTextTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      NOTIFICATION-GROUP
+        FROM SNMPv2-CONF;
+
+    testNotificationGroup NOTIFICATION-GROUP
+       NOTIFICATIONS    {
+                            testStatusChangeNotify,
+                            testClassEventNotify,
+                            testThresholdBelowNotify
+                        }
+        STATUS          obsolete
+        DESCRIPTION     "A collection of \\n test
+     notifications."
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        docstring = textwrap.dedent(self.__class__.__doc__)
+        ast = parserFactory()().parse(docstring)[0]
+        mibInfo, symtable = SymtableCodeGen().gen_code(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().gen_code(
+            ast,
+            {mibInfo.name: symtable},
+            genTexts=True,
+            textFilter=lambda symbol, text: text,
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        mibBuilder = MibBuilder()
+        mibBuilder.loadTexts = True
+
+        self.ctx = {"mibBuilder": mibBuilder}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testNotificationGroupStatus(self):
+        # Use a value other than "current" in this test, as "current" is the
+        # default pysnmp value (which could mean the test value was never set).
+        self.assertEqual(
+            self.ctx["testNotificationGroup"].getStatus(),
+            "obsolete",
+            "bad STATUS",
+        )
+
+    def testNotificationGroupDescription(self):
+        self.assertEqual(
+            self.ctx["testNotificationGroup"].getDescription(),
+            "A collection of \\n test\n notifications.",
+            "bad DESCRIPTION",
+        )
+
+
+class NotificationGroupNoLoadTextsTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      NOTIFICATION-GROUP
+        FROM SNMPv2-CONF;
+
+    testNotificationGroup NOTIFICATION-GROUP
+       NOTIFICATIONS    {
+                            testStatusChangeNotify,
+                            testClassEventNotify,
+                            testThresholdBelowNotify
+                        }
+        STATUS          deprecated
+        DESCRIPTION
+            "A collection of test notifications."
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().gen_code(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().gen_code(
+            ast, {mibInfo.name: symtable}, genTexts=True
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testNotificationGroupStatus(self):
+        # "current" is the default pysnmp value, and therefore what we get if
+        # we request that texts not be loaded.
+        self.assertEqual(
+            self.ctx["testNotificationGroup"].getStatus(),
+            "current",
+            "bad STATUS",
+        )
+
+    def testNotificationGroupDescription(self):
+        self.assertEqual(
+            self.ctx["testNotificationGroup"].getDescription(),
+            "",
+            "bad DESCRIPTION",
         )
 
 

--- a/tests/test_notificationgroup_smiv2_pysnmp.py
+++ b/tests/test_notificationgroup_smiv2_pysnmp.py
@@ -105,7 +105,7 @@ class NotificationGroupHyphenTestCase(unittest.TestCase):
 
     test-notification-group NOTIFICATION-GROUP
        NOTIFICATIONS    {
-                            testStatusChangeNotify
+                            test-status-change-notify
                         }
         STATUS          current
         DESCRIPTION
@@ -133,6 +133,13 @@ class NotificationGroupHyphenTestCase(unittest.TestCase):
             self.ctx["test_notification_group"].getLabel(),
             "test-notification-group",
             "bad label",
+        )
+
+    def testNotificationGroupObjects(self):
+        self.assertEqual(
+            self.ctx["test_notification_group"].getObjects(),
+            (("TEST-MIB", "test-status-change-notify"),),
+            "bad OBJECTS",
         )
 
 

--- a/tests/test_notificationgroup_smiv2_pysnmp.py
+++ b/tests/test_notificationgroup_smiv2_pysnmp.py
@@ -77,6 +77,17 @@ class NotificationGroupTestCase(unittest.TestCase):
             "bad DESCRIPTION",
         )
 
+    def testNotificationGroupObjects(self):
+        self.assertEqual(
+            self.ctx["testNotificationGroup"].getObjects(),
+            (
+                ("TEST-MIB", "testStatusChangeNotify"),
+                ("TEST-MIB", "testClassEventNotify"),
+                ("TEST-MIB", "testThresholdBelowNotify"),
+            ),
+            "bad OBJECTS",
+        )
+
     def testNotificationGroupClass(self):
         self.assertEqual(
             self.ctx["testNotificationGroup"].__class__.__name__,

--- a/tests/test_notificationtype_smiv2_pysnmp.py
+++ b/tests/test_notificationtype_smiv2_pysnmp.py
@@ -98,8 +98,8 @@ class NotificationTypeHyphenTestCase(unittest.TestCase):
 
     test-notification-type NOTIFICATION-TYPE
        OBJECTS         {
-                            testChangeConfigType,
-                            testChangeConfigValue
+                            test-change-config-type,
+                            as                        -- a reserved Python keyword
                         }
         STATUS          current
         DESCRIPTION
@@ -127,6 +127,16 @@ class NotificationTypeHyphenTestCase(unittest.TestCase):
             self.ctx["test_notification_type"].getLabel(),
             "test-notification-type",
             "bad name",
+        )
+
+    def testNotificationTypeObjects(self):
+        self.assertEqual(
+            self.ctx["test_notification_type"].getObjects(),
+            (
+                ("TEST-MIB", "test-change-config-type"),
+                ("TEST-MIB", "as"),
+            ),
+            "bad OBJECTS",
         )
 
 

--- a/tests/test_notificationtype_smiv2_pysnmp.py
+++ b/tests/test_notificationtype_smiv2_pysnmp.py
@@ -71,6 +71,16 @@ class NotificationTypeTestCase(unittest.TestCase):
             "bad DESCRIPTION",
         )
 
+    def testNotificationTypeObjects(self):
+        self.assertEqual(
+            self.ctx["testNotificationType"].getObjects(),
+            (
+                ("TEST-MIB", "testChangeConfigType"),
+                ("TEST-MIB", "testChangeConfigValue"),
+            ),
+            "bad OBJECTS",
+        )
+
     def testNotificationTypeClass(self):
         self.assertEqual(
             self.ctx["testNotificationType"].__class__.__name__,

--- a/tests/test_notificationtype_smiv2_pysnmp.py
+++ b/tests/test_notificationtype_smiv2_pysnmp.py
@@ -59,6 +59,11 @@ class NotificationTypeTestCase(unittest.TestCase):
     def testNotificationTypeName(self):
         self.assertEqual(self.ctx["testNotificationType"].getName(), (1, 3), "bad name")
 
+    def testNotificationTypeStatus(self):
+        self.assertEqual(
+            self.ctx["testNotificationType"].getStatus(), "current", "bad STATUS"
+        )
+
     def testNotificationTypeDescription(self):
         self.assertEqual(
             self.ctx["testNotificationType"].getDescription(),
@@ -112,6 +117,103 @@ class NotificationTypeHyphenTestCase(unittest.TestCase):
             self.ctx["test_notification_type"].getLabel(),
             "test-notification-type",
             "bad name",
+        )
+
+
+class NotificationTypeTextTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      NOTIFICATION-TYPE
+        FROM SNMPv2-SMI;
+
+    testNotificationType NOTIFICATION-TYPE
+        OBJECTS         {
+                            testChangeConfigType,
+                            testChangeConfigValue
+                        }
+        STATUS          deprecated
+        DESCRIPTION
+            "A collection of \\ test notification types.\\"
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().gen_code(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().gen_code(
+            ast, {mibInfo.name: symtable}, genTexts=True
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        mibBuilder = MibBuilder()
+        mibBuilder.loadTexts = True
+
+        self.ctx = {"mibBuilder": mibBuilder}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testNotificationTypeStatus(self):
+        # Use a value other than "current" in this test, as "current" is the
+        # default pysnmp value (which could mean the test value was never set).
+        self.assertEqual(
+            self.ctx["testNotificationType"].getStatus(), "deprecated", "bad STATUS"
+        )
+
+    def testNotificationTypeDescription(self):
+        self.assertEqual(
+            self.ctx["testNotificationType"].getDescription(),
+            "A collection of \\ test notification types.\\",
+            "bad DESCRIPTION",
+        )
+
+
+class NotificationTypeNoLoadTextsTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      NOTIFICATION-TYPE
+        FROM SNMPv2-SMI;
+
+    testNotificationType NOTIFICATION-TYPE
+       OBJECTS         {
+                            testChangeConfigType,
+                            testChangeConfigValue
+                        }
+        STATUS          obsolete
+        DESCRIPTION
+            "A collection of test notification types."
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().gen_code(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().gen_code(
+            ast, {mibInfo.name: symtable}, genTexts=True
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testNotificationTypeStatus(self):
+        # "current" is the default pysnmp value, and therefore what we get if
+        # we request that texts not be loaded.
+        self.assertEqual(
+            self.ctx["testNotificationType"].getStatus(), "current", "bad STATUS"
+        )
+
+    def testNotificationTypeDescription(self):
+        self.assertEqual(
+            self.ctx["testNotificationType"].getDescription(),
+            "",
+            "bad DESCRIPTION",
         )
 
 

--- a/tests/test_objectgroup_smiv2_pysnmp.py
+++ b/tests/test_objectgroup_smiv2_pysnmp.py
@@ -97,8 +97,8 @@ class ObjectGroupHyphenTestCase(unittest.TestCase):
 
     test-object-group OBJECT-GROUP
         OBJECTS         {
-                            testStorageType,
-                            testRowStatus
+                            test-storage-type,
+                            global              -- a reserved Python keyword
                         }
         STATUS          current
         DESCRIPTION
@@ -124,6 +124,13 @@ class ObjectGroupHyphenTestCase(unittest.TestCase):
     def testObjectGroupLabel(self):
         self.assertEqual(
             self.ctx["test_object_group"].getLabel(), "test-object-group", "bad label"
+        )
+
+    def testObjectGroupObjects(self):
+        self.assertEqual(
+            self.ctx["test_object_group"].getObjects(),
+            (("TEST-MIB", "test-storage-type"), ("TEST-MIB", "global")),
+            "bad OBJECTS",
         )
 
 

--- a/tests/test_objectgroup_smiv2_pysnmp.py
+++ b/tests/test_objectgroup_smiv2_pysnmp.py
@@ -5,6 +5,7 @@
 # License: https://www.pysnmp.com/pysmi/license.html
 #
 import sys
+import textwrap
 
 try:
     import unittest2 as unittest
@@ -59,6 +60,11 @@ class ObjectGroupTestCase(unittest.TestCase):
 
     def testObjectGroupName(self):
         self.assertEqual(self.ctx["testObjectGroup"].getName(), (1, 3), "bad name")
+
+    def testObjectGroupStatus(self):
+        self.assertEqual(
+            self.ctx["testObjectGroup"].getStatus(), "current", "bad STATUS"
+        )
 
     def testObjectGroupDescription(self):
         self.assertEqual(
@@ -118,6 +124,108 @@ class ObjectGroupHyphenTestCase(unittest.TestCase):
     def testObjectGroupLabel(self):
         self.assertEqual(
             self.ctx["test_object_group"].getLabel(), "test-object-group", "bad label"
+        )
+
+
+class ObjectGroupTextTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-GROUP
+        FROM SNMPv2-CONF;
+
+    testObjectGroup OBJECT-GROUP
+        OBJECTS         {
+                            testStorageType,
+                            testRowStatus
+                        }
+        STATUS          deprecated
+        DESCRIPTION
+            "A collection of test objects.
+    "
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        docstring = textwrap.dedent(self.__class__.__doc__)
+        ast = parserFactory(**smi_v2)().parse(docstring)[0]
+        mibInfo, symtable = SymtableCodeGen().gen_code(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().gen_code(
+            ast,
+            {mibInfo.name: symtable},
+            genTexts=True,
+            textFilter=lambda symbol, text: text,
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        mibBuilder = MibBuilder()
+        mibBuilder.loadTexts = True
+
+        self.ctx = {"mibBuilder": mibBuilder}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectGroupStatus(self):
+        # Use a value other than "current" in this test, as "current" is the
+        # default pysnmp value (which could mean the test value was never set).
+        self.assertEqual(
+            self.ctx["testObjectGroup"].getStatus(), "deprecated", "bad STATUS"
+        )
+
+    def testObjectGroupDescription(self):
+        self.assertEqual(
+            self.ctx["testObjectGroup"].getDescription(),
+            "A collection of test objects.\n",
+            "bad DESCRIPTION",
+        )
+
+
+class ObjectGroupNoLoadTextsTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-GROUP
+        FROM SNMPv2-CONF;
+
+    testObjectGroup OBJECT-GROUP
+        OBJECTS         {
+                            testStorageType,
+                            testRowStatus
+                        }
+        STATUS          obsolete
+        DESCRIPTION
+            "A collection of test objects."
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory(**smi_v2)().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().gen_code(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().gen_code(
+            ast, {mibInfo.name: symtable}, genTexts=True
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectGroupStatus(self):
+        # "current" is the default pysnmp value, and therefore what we get if
+        # we request that texts not be loaded.
+        self.assertEqual(
+            self.ctx["testObjectGroup"].getStatus(), "current", "bad STATUS"
+        )
+
+    def testObjectGroupDescription(self):
+        self.assertEqual(
+            self.ctx["testObjectGroup"].getDescription(),
+            "",
+            "bad DESCRIPTION",
         )
 
 

--- a/tests/test_objectidentity_smiv2_pysnmp.py
+++ b/tests/test_objectidentity_smiv2_pysnmp.py
@@ -5,6 +5,7 @@
 # License: https://www.pysnmp.com/pysmi/license.html
 #
 import sys
+import textwrap
 
 try:
     import unittest2 as unittest
@@ -56,6 +57,9 @@ class ObjectIdentityTestCase(unittest.TestCase):
     def testObjectIdentityName(self):
         self.assertEqual(self.ctx["testObject"].getName(), (1, 3), "bad name")
 
+    def testObjectIdentityStatus(self):
+        self.assertEqual(self.ctx["testObject"].getStatus(), "current", "bad STATUS")
+
     def testObjectIdentityDescription(self):
         self.assertEqual(
             self.ctx["testObject"].getDescription(),
@@ -105,6 +109,104 @@ class ObjectIdentityHyphenTestCase(unittest.TestCase):
 
     def testObjectIdentityLabel(self):
         self.assertEqual(self.ctx["test_object"].getLabel(), "test-object", "bad label")
+
+
+class ObjectIdentityTextTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+        OBJECT-IDENTITY
+    FROM SNMPv2-SMI;
+
+    testObject OBJECT-IDENTITY
+        STATUS          obsolete
+        DESCRIPTION     "\\'Initial' version"
+        REFERENCE       "
+    "
+
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        docstring = textwrap.dedent(self.__class__.__doc__)
+        ast = parserFactory()().parse(docstring)[0]
+        mibInfo, symtable = SymtableCodeGen().gen_code(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().gen_code(
+            ast,
+            {mibInfo.name: symtable},
+            genTexts=True,
+            textFilter=lambda symbol, text: text,
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        mibBuilder = MibBuilder()
+        mibBuilder.loadTexts = True
+
+        self.ctx = {"mibBuilder": mibBuilder}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectIdentityStatus(self):
+        # Use a value other than "current" in this test, as "current" is the
+        # default pysnmp value (which could mean the test value was never set).
+        self.assertEqual(self.ctx["testObject"].getStatus(), "obsolete", "bad STATUS")
+
+    def testObjectIdentityDescription(self):
+        self.assertEqual(
+            self.ctx["testObject"].getDescription(),
+            "\\'Initial' version",
+            "bad DESCRIPTION",
+        )
+
+    def testObjectIdentityReference(self):
+        self.assertEqual(self.ctx["testObject"].getReference(), "\n", "bad REFERENCE")
+
+
+class ObjectIdentityNoLoadTextsTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+        OBJECT-IDENTITY
+    FROM SNMPv2-SMI;
+
+    testObject OBJECT-IDENTITY
+        STATUS          deprecated
+        DESCRIPTION     "Initial version"
+        REFERENCE       "ABC"
+
+     ::= { 1 3 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().gen_code(ast, {}, genTexts=True)
+        self.mibInfo, pycode = PySnmpCodeGen().gen_code(
+            ast, {mibInfo.name: symtable}, genTexts=True
+        )
+        codeobj = compile(pycode, "test", "exec")
+
+        self.ctx = {"mibBuilder": MibBuilder()}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+    def testObjectIdentityStatus(self):
+        # "current" is the default pysnmp value, and therefore what we get if
+        # we request that texts not be loaded.
+        self.assertEqual(self.ctx["testObject"].getStatus(), "current", "bad STATUS")
+
+    def testObjectIdentityDescription(self):
+        self.assertEqual(
+            self.ctx["testObject"].getDescription(),
+            "",
+            "bad DESCRIPTION",
+        )
+
+    def testObjectIdentityReference(self):
+        self.assertEqual(self.ctx["testObject"].getReference(), "", "bad REFERENCE")
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_syntaxname_smiv2_pysnmp.py
+++ b/tests/test_syntaxname_smiv2_pysnmp.py
@@ -1,0 +1,368 @@
+#
+# This file is part of pysmi software.
+#
+# Copyright (c) 2015-2020, Ilya Etingof; Copyright (c) 2022-2024, others
+# License: https://www.pysnmp.com/pysmi/license.html
+#
+import sys
+import textwrap
+
+try:
+    import unittest2 as unittest
+
+except ImportError:
+    import unittest
+
+from pysmi.parser.smi import parserFactory
+from pysmi.codegen.pysnmp import PySnmpCodeGen
+from pysmi.codegen.symtable import SymtableCodeGen
+from pysnmp.smi.builder import MibBuilder
+from pysnmp.smi.view import MibViewController
+
+
+def decor(func, symbol, klass):
+    def inner(self):
+        func(self, symbol, klass)
+
+    return inner
+
+
+class SyntaxNameLocalTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-TYPE,
+      Integer32
+        FROM SNMPv2-SMI
+      TEXTUAL-CONVENTION
+        FROM SNMPv2-TC;
+
+    testObject1 OBJECT-TYPE
+        SYNTAX       Integer32
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+      ::= { 1 4 1 }
+
+    testObject2 OBJECT-TYPE
+        SYNTAX       Integer32 (0..9)
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+      ::= { 1 4 2 }
+
+    testObject3 OBJECT-TYPE
+        SYNTAX       BITS { value(0), otherValue(1) }
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+      ::= { 1 4 3 }
+
+    testObject4 OBJECT-TYPE
+        SYNTAX       Integer32
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+        DEFVAL       { 0 }
+      ::= { 1 4 4 }
+
+    TestTypeI ::= Integer32
+    TestTypeB ::= BITS { value(0), otherValue(1) }
+
+    testObject5 OBJECT-TYPE
+        SYNTAX       TestTypeI
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+      ::= { 1 4 5 }
+
+    testObject6 OBJECT-TYPE
+        SYNTAX       TestTypeI (2..5)
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+      ::= { 1 4 6 }
+
+    testObject7 OBJECT-TYPE
+        SYNTAX       TestTypeB { value(0) }
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+      ::= { 1 4 7 }
+
+    testObject8 OBJECT-TYPE
+        SYNTAX       TestTypeI
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+        DEFVAL       { 0 }
+      ::= { 1 4 8 }
+
+    TestTCI ::= TEXTUAL-CONVENTION
+        STATUS       current
+        DESCRIPTION  "Test TC"
+        SYNTAX       Integer32
+
+    TestTCB ::= TEXTUAL-CONVENTION
+        STATUS       current
+        DESCRIPTION  "Test TC"
+        SYNTAX       BITS { value(0), otherValue(1) }
+
+    testObject9 OBJECT-TYPE
+        SYNTAX       TestTCI
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+      ::= { 1 4 9 }
+
+    testObject10 OBJECT-TYPE
+        SYNTAX       TestTCI (2..5)
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+      ::= { 1 4 10 }
+
+    testObject11 OBJECT-TYPE
+        SYNTAX       TestTCB { value(0) }
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+      ::= { 1 4 11 }
+
+    testObject12 OBJECT-TYPE
+        SYNTAX       TestTCI
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+        DEFVAL       { 0 }
+      ::= { 1 4 12 }
+
+    Test-Hyphen-TC ::= TEXTUAL-CONVENTION
+        STATUS       current
+        DESCRIPTION  "Test TC"
+        SYNTAX       Integer32
+
+    testObject13 OBJECT-TYPE
+        SYNTAX       Test-Hyphen-TC
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+      ::= { 1 4 13 }
+
+    testObject14 OBJECT-TYPE
+        SYNTAX       Test-Hyphen-TC (2..5)
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION  "Test object"
+      ::= { 1 4 14 }
+
+    END
+    """
+
+    def setUp(self):
+        ast = parserFactory()().parse(self.__class__.__doc__)[0]
+        mibInfo, symtable = SymtableCodeGen().gen_code(ast, {})
+        self.mibInfo, pycode = PySnmpCodeGen().gen_code(ast, {mibInfo.name: symtable})
+        codeobj = compile(pycode, "test", "exec")
+
+        mibBuilder = MibBuilder()
+
+        self.ctx = {"mibBuilder": mibBuilder}
+
+        exec(codeobj, self.ctx, self.ctx)
+
+        self.mibViewController = MibViewController(mibBuilder)
+
+    def protoTestObjectTypeSyntaxName(self, symbol, name):
+        self.assertEqual(
+            self.ctx[symbol].getSyntax().__class__.__name__,
+            name,
+            f"bad SYNTAX NAME for {symbol}",
+        )
+
+    def protoTestObjectTypeSyntaxClass(self, symbol, name):
+        self.assertTrue(
+            issubclass(self.ctx[symbol].getSyntax().__class__, self.ctx[name]),
+            f"bad SYNTAX CLASS for {symbol}",
+        )
+
+
+syntaxNamesMap = (
+    ("1", "Integer32"),
+    ("2", "Integer32"),
+    ("3", "Bits"),
+    ("4", "Integer32"),
+    ("5", "TestTypeI"),
+    ("6", "TestTypeI"),
+    ("7", "TestTypeB"),
+    ("8", "TestTypeI"),
+    ("9", "TestTCI"),
+    ("10", "TestTCI"),
+    ("11", "TestTCB"),
+    ("12", "TestTCI"),
+    ("13", "Test_Hyphen_TC"),
+    ("14", "Test_Hyphen_TC"),
+)
+
+
+for n, k in syntaxNamesMap:
+    setattr(
+        SyntaxNameLocalTestCase,
+        "testObjectTypeSyntaxName" + n,
+        decor(
+            SyntaxNameLocalTestCase.protoTestObjectTypeSyntaxName, f"testObject{n}", k
+        ),
+    )
+
+    # The class name of the syntax must itself be a symbol that identifies a
+    # base class of that syntax.
+    setattr(
+        SyntaxNameLocalTestCase,
+        "testObjectTypeSyntaxClass" + n,
+        decor(
+            SyntaxNameLocalTestCase.protoTestObjectTypeSyntaxClass, f"testObject{n}", k
+        ),
+    )
+
+
+class SyntaxNameImportTestCase(unittest.TestCase):
+    """
+    TEST-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-TYPE
+        FROM SNMPv2-SMI
+      TEXTUAL-CONVENTION
+        FROM SNMPv2-TC
+      ImportedType1, Imported-Type-2
+        FROM IMPORTED-MIB;
+
+    testObject1 OBJECT-TYPE
+        SYNTAX      ImportedType1
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION "Test object"
+      ::= { 1 4 1 }
+
+    testObject2 OBJECT-TYPE
+        SYNTAX      ImportedType1 (2..5)
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION "Test object"
+      ::= { 1 4 2 }
+
+    testObject3 OBJECT-TYPE
+        SYNTAX      ImportedType1
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION "Test object"
+        DEFVAL      { 0 }
+      ::= { 1 4 3 }
+
+    testObject4 OBJECT-TYPE
+        SYNTAX      Imported-Type-2
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION "Test object"
+      ::= { 1 4 4 }
+
+    testObject5 OBJECT-TYPE
+        SYNTAX      Imported-Type-2 { value(0) }
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION "Test object"
+      ::= { 1 4 5 }
+
+    testObject6 OBJECT-TYPE
+        SYNTAX      Imported-Type-2
+        MAX-ACCESS  read-only
+        STATUS      current
+        DESCRIPTION "Test object"
+        DEFVAL      { { otherValue } }
+      ::= { 1 4 6 }
+
+    END
+    """
+
+    IMPORTED_MIB = """
+    IMPORTED-MIB DEFINITIONS ::= BEGIN
+    IMPORTS
+      OBJECT-TYPE, Integer32
+        FROM SNMPv2-SMI
+      TEXTUAL-CONVENTION
+        FROM SNMPv2-TC;
+
+    ImportedType1 ::= TEXTUAL-CONVENTION
+        STATUS       current
+        DESCRIPTION  "Test TC"
+        SYNTAX       Integer32
+
+    Imported-Type-2 ::= TEXTUAL-CONVENTION
+        STATUS       current
+        DESCRIPTION  "Test TC"
+        SYNTAX       BITS { value(0), otherValue(1) }
+
+    END
+    """
+
+    def setUp(self):
+        self.ctx = {"mibBuilder": MibBuilder()}
+        symbolTable = {}
+
+        for mibData in (self.IMPORTED_MIB, self.__class__.__doc__):
+            ast = parserFactory()().parse(mibData)[0]
+            mibInfo, symtable = SymtableCodeGen().gen_code(ast, {})
+
+            symbolTable[mibInfo.name] = symtable
+
+            mibInfo, pycode = PySnmpCodeGen().gen_code(ast, dict(symbolTable))
+            codeobj = compile(pycode, "test", "exec")
+            exec(codeobj, self.ctx, self.ctx)
+
+    def protoTestObjectTypeSyntaxName(self, symbol, name):
+        self.assertEqual(
+            self.ctx[symbol].getSyntax().__class__.__name__,
+            name,
+            f"bad SYNTAX NAME for {symbol}",
+        )
+
+    def protoTestObjectTypeSyntaxClass(self, symbol, name):
+        self.assertTrue(
+            issubclass(self.ctx[symbol].getSyntax().__class__, self.ctx[name]),
+            f"bad SYNTAX CLASS for {symbol}",
+        )
+
+
+syntaxNamesMap = (
+    ("1", "ImportedType1"),
+    ("2", "ImportedType1"),
+    ("3", "ImportedType1"),
+    ("4", "Imported_Type_2"),
+    ("5", "Imported_Type_2"),
+    ("6", "Imported_Type_2"),
+)
+
+
+for n, k in syntaxNamesMap:
+    setattr(
+        SyntaxNameImportTestCase,
+        "testObjectTypeSyntaxName" + n,
+        decor(
+            SyntaxNameImportTestCase.protoTestObjectTypeSyntaxName, f"testObject{n}", k
+        ),
+    )
+
+    # The class name of the syntax must itself be a symbol that identifies a
+    # base class of that syntax.
+    setattr(
+        SyntaxNameImportTestCase,
+        "testObjectTypeSyntaxClass" + n,
+        decor(
+            SyntaxNameImportTestCase.protoTestObjectTypeSyntaxClass, f"testObject{n}", k
+        ),
+    )
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == "__main__":
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/test_traptype_smiv1_pysnmp.py
+++ b/tests/test_traptype_smiv1_pysnmp.py
@@ -73,6 +73,13 @@ class TrapTypeTestCase(unittest.TestCase):
             self.ctx["testTrap"].getDescription(), "Test trap", "bad DESCRIPTION"
         )
 
+    def testTrapTypeObjects(self):
+        self.assertEqual(
+            self.ctx["testTrap"].getObjects(),
+            (("TEST-MIB", "testObject"),),
+            "bad OBJECTS",
+        )
+
     def testTrapTypeClass(self):
         self.assertEqual(
             self.ctx["testTrap"].__class__.__name__,

--- a/tests/test_traptype_smiv1_pysnmp.py
+++ b/tests/test_traptype_smiv1_pysnmp.py
@@ -133,6 +133,13 @@ class TrapTypeHyphenTestCase(unittest.TestCase):
     def testTrapTypeLabel(self):
         self.assertEqual(self.ctx["test_trap"].getLabel(), "test-trap", "bad label")
 
+    def testTrapTypeObjects(self):
+        self.assertEqual(
+            self.ctx["test_trap"].getObjects(),
+            (("TEST-MIB", "test-object"),),
+            "bad OBJECTS",
+        )
+
 
 class TrapTypeTextTestCase(unittest.TestCase):
     """


### PR DESCRIPTION
pysnmp comes with a set of built-in "base" MIBs, in `pysnmp/smi/mibs/`. By far most of those base MIBs have been compiled by pysmi, with a subset of the resulting Python modules modified by hand afterward. However, it has been quite a while since pysmi was last used to generate those base MIBs, and the current versions have a few problems (e.g., some missing access levels) that regeneration would resolve. Of course, such issues can also be resolved by hand, but I would say that for the overall maintenance of pysnmp, it will be a good thing to re-learn how such base MIB regeneration can be done at all: that way, when future updates are made to either the source MIBs themselves or to the structure of the generated Python code, such updates no longer all have to be applied to pysnmp by hand.

I believe I have indeed succeeded in establishing the process of regenerating the base MIBs. That also proved to be a good quality check for pysmi. An analysis of the differences in both generated code and resulting MIB tree details exposed by pysnmp, revealed a few bugs and deficiencies in pysmi. As before, most of these can be traced back to pysmi's switch to Jinja2 templates; the pysnmp base MIBs had not been regenerated since then.

The primary purpose of this PR is to resolve those differences, thereby improving pysmi's level of quality to the point that it can indeed be used to regenerate the pysnmp base MIBs again, without losing anything (at least, to the extent that I can tell!) in the process. Specifically: the first four of the commits in this PR resolve functional differences, and the last one makes the generated contents look a bit more similar and sensible. The fifth commit ('Improve on the use of symbol "Pythonization"') is a related improvement of pysmi's own code (and test set), although it has no effect on the generated base MIBs.

Once again, these changes have been tested with the script from PR #3. The statistics respectively before and after (against lextudio/mibs.pysnmp.com@aa51f794) are as follows:

    MIB results: 11924 total, 10034 successful, 1014 failed to compile, 709 failed to load, 100 failed on dependency, 67 failed for other reasons
    MIB results: 11924 total, 10034 successful, 1012 failed to compile, 709 failed to load, 102 failed on dependency, 67 failed for other reasons

As can be seen, the *quantitative* impact of this branch is minimal. As a result of the DEFVAL commit, two MIBs that previously triggered an exception during compilation, now fail in the next phase (dependencies) instead.

In terms of *quality* however, there are more differences: most notably, 2065 of the compiled MIBs now have extra default values that were previously missing, and 2847 of the compiled MIBs now have their ModuleCompliance classes contain the intended lists of objects. Note that not all of those affected MIBs can be loaded (it is a bit too much work to filter those out from these statistics).

As part of this PR, the pysmi test set is extended from 266 to 393 tests.

If and when this PR is accepted, my plan is to submit a subsequent PR for pysnmp that indeed updates the base MIBs, including instructions on how to do that again later.

P.S. This PR deliberately does *not* change pysmi to apply the recent pysnmp PEP-8 update from importSymbols to import_symbols and exportSymbols to export_symbols. Doing so would break all pysmi-generated code for use by pysnmp versions before that PEP-8 update, and I am not sufficiently familiar with the versioning strategy to tell whether that would be a problem. That means that for now, the pysmi-generated MIBs (base or not) will continue to use importSymbols/exportSymbols, and changing the base MIBs to use import_symbols/export_symbols will remain a manual step afterward for now (but with e.g. `sed`, a rather easy one!).