### PR TITLE
Register fixed lengths for octet strings

### DIFF
--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -151,6 +151,9 @@ if mibBuilder.loadTexts:
         ValueSizeConstraint({{ range['min'] }}, {{ range['max'] }}),
         {% endfor %}
     )
+        {% if 'fixed' in spec %}
+    fixedLength = {{ spec['fixed'] }}
+        {% endif %}
     {% endif %}
 {% endmacro -%}
 


### PR DESCRIPTION
This PR restores pysmi's `fixedLength` field generation. As such, it is the fix for point (2) of my (first) comment in lextudio/pysnmp#141. That should allow fixes for pysnmp for the other two points from that comment to restore proper generation and parsing of OIDs with fixed-length string indices.

This PR does not change the mibs.pysnmp.com statistics (i.e., no regressions), but there are now 9969 `fixedLength` assignments across 2085 MIBs from that collection that were missing before, and those numbers are very close to the pre-Jinja2 numbers from there (9954 assignments across 2088 MIBs). Note that the collection itself has been slightly altered since then, so an exact match is not expected there. In any case, I think this is looking good.

In addition, the pysmi test set is extended to 510 tests.