### PR TITLE
Set stacklevel=2 for DeprecationWarning

### DIFF
--- a/pysmi/reader/url.py
+++ b/pysmi/reader/url.py
@@ -54,7 +54,9 @@ def __getattr__(attr: str):
     """Handle deprecated attributes."""
     if newAttr := deprecated_attributes.get(attr):
         warnings.warn(
-            f"{attr} is deprecated. Please use {newAttr} instead.", DeprecationWarning
+            f"{attr} is deprecated. Please use {newAttr} instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
         return globals()[newAttr]
     raise AttributeError(f"module {__name__} has no attribute {attr}")


### PR DESCRIPTION
Emit DeprecationWarning for caller. All other `__getattr__` functions already set `stacklevel=2` correctly.

https://github.com/lextudio/pysmi/blob/65442a53025017f3b76b27e588f1bfc03d512761/pysmi/parser/dialect.py#L41-L45