### PR TITLE
PySMI Fixed OID Length PEP 8 Compliance

### DIFF
--- a/pysmi/codegen/templates/pysnmp/mib-definitions.j2
+++ b/pysmi/codegen/templates/pysnmp/mib-definitions.j2
@@ -152,7 +152,7 @@ if mibBuilder.loadTexts:
         {% endfor %}
     )
         {% if 'fixed' in spec %}
-    fixedLength = {{ spec['fixed'] }}
+    fixed_length = {{ spec['fixed'] }}
         {% endif %}
     {% endif %}
 {% endmacro -%}

--- a/tests/test_typedeclaration_smiv2_pysnmp.py
+++ b/tests/test_typedeclaration_smiv2_pysnmp.py
@@ -149,14 +149,14 @@ class TypeDeclarationTestCase(unittest.TestCase):
 
     def protoTestIsFixedLength(self, symbol, length_or_none):
         self.assertEqual(
-            self.ctx[symbol]().isFixedLength(),
+            self.ctx[symbol]().is_fixed_length(),
             length_or_none is not None,
             f"wrong fixed length presence for symbol {symbol}",
         )
 
     def protoTestGetFixedLength(self, symbol, length_or_none):
         self.assertEqual(
-            self.ctx[symbol]().getFixedLength(),
+            self.ctx[symbol]().get_fixed_length(),
             length_or_none,
             f"wrong fixed length for symbol {symbol}",
         )
@@ -984,14 +984,14 @@ class TypeDeclarationFixedLengthTestCase(unittest.TestCase):
 
     def protoTestIsFixedLength(self, symbol, length_or_none):
         self.assertEqual(
-            self.ctx[symbol].getSyntax().isFixedLength(),
+            self.ctx[symbol].getSyntax().is_fixed_length(),
             length_or_none is not None,
             f"wrong fixed length presence for symbol {symbol}",
         )
 
     def protoTestGetFixedLength(self, symbol, length_or_none):
         self.assertEqual(
-            self.ctx[symbol].getSyntax().getFixedLength(),
+            self.ctx[symbol].getSyntax().get_fixed_length(),
             length_or_none,
             f"wrong fixed length for symbol {symbol}",
         )


### PR DESCRIPTION
This updates pysmi to match the changes to pysnmp for PEP 8 compliance.

The fixed_length attribute that is generated is updated as well as the corresponding unit tests