### PR TITLE
Fixed debugging when using Mibdump.

### DIFF
--- a/pysmi/lexer/smi.py
+++ b/pysmi/lexer/smi.py
@@ -188,12 +188,12 @@ class SmiV2Lexer(AbstractLexer):
             )
         else:
             if debug.logger & debug.FLAG_LEXER:
-                logger = debug.logger.getCurrentLogger()
+                logger = debug.logger.get_current_logger()
             else:
                 logger = lex.NullLogger()
 
             if debug.logger & debug.FLAG_GRAMMAR:
-                debuglogger = debug.logger.getCurrentLogger()
+                debuglogger = debug.logger.get_current_logger()
             else:
                 debuglogger = None
 

--- a/pysmi/parser/smi.py
+++ b/pysmi/parser/smi.py
@@ -46,12 +46,12 @@ class SmiV2Parser(AbstractParser):
             )
         else:
             if debug.logger & debug.FLAG_PARSER:
-                logger = debug.logger.getCurrentLogger()
+                logger = debug.logger.get_current_logger()
             else:
                 logger = yacc.NullLogger()
 
             if debug.logger & debug.FLAG_GRAMMAR:
-                debuglogger = debug.logger.getCurrentLogger()
+                debuglogger = debug.logger.get_current_logger()
             else:
                 debuglogger = None
 


### PR DESCRIPTION
Hello!
First of all, sorry for the extended wait. This was due to May 8, but here I am, May 27. hehe.

So, recap of the PR:

When enabling debugging of the mibdump command through the --debug=all flag, the command fails completely due to broken referencing.

One of its calls to invoke the logger, "getCurrentLogger" was pythonized to "get_current_logger". But this was not updated in the following files:

/pysmi/parser/smi.py
/pysmi/lexer/smi.py

This PR fixes this in both of these files.