### PR TITLE
fix: add namedConstraintValue to tolerate identifiers in integer subtypes

### DIFF
--- a/pysmi/lexer/smi.py
+++ b/pysmi/lexer/smi.py
@@ -534,6 +534,7 @@ relaxedGrammar = {
     "lowcaseIdentifier": [],
     "curlyBracesAroundEnterpriseInTrap": [],
     "noCells": [],
+    "namedConstraintValue": [],
 }
 
 

--- a/pysmi/parser/dialect.py
+++ b/pysmi/parser/dialect.py
@@ -26,6 +26,7 @@ smi_v1_relaxed.update(
     lowcaseIdentifier=True,
     curlyBracesAroundEnterpriseInTrap=True,
     noCells=True,
+    namedConstraintValue=True,
 )
 
 # Compatibility API

--- a/pysmi/parser/smi.py
+++ b/pysmi/parser/smi.py
@@ -1420,6 +1420,23 @@ class NoCells:
             p[0] = (p[1], p[3])
 
 
+# noinspection PyIncorrectDocstring
+class NamedConstraintValue:
+    # tolerate identifiers as named constraint values in integer subtypes
+    # e.g. SYNTAX Unsigned32 (WAN7 | WAN8) where WAN7/WAN8 are defined TCs
+    @staticmethod
+    def p_value(self, p):
+        """value : NEGATIVENUMBER
+        | NUMBER
+        | NEGATIVENUMBER64
+        | NUMBER64
+        | HEX_STRING
+        | BIN_STRING
+        | UPPERCASE_IDENTIFIER
+        | LOWERCASE_IDENTIFIER"""
+        p[0] = p[1]
+
+
 relaxedGrammar = {
     "supportSmiV1Keywords": [
         SupportSmiV1Keywords.p_importedKeyword,
@@ -1438,6 +1455,7 @@ relaxedGrammar = {
         CurlyBracesInEnterprises.p_EnterprisePart,
     ],
     "noCells": [NoCells.p_CreationPart],
+    "namedConstraintValue": [NamedConstraintValue.p_value],
 }
 
 
@@ -1464,6 +1482,7 @@ def parserFactory(**grammarOptions):
         * lowcaseIdentifier - tolerate lowercase MIB identifiers
         * curlyBracesAroundEnterpriseInTrap - tolerate curly braces around enterprise ID in TRAP MACRO
         * noCells - tolerate missing cells (XXX)
+        * namedConstraintValue - tolerate identifiers as named constraint values in integer subtypes
 
     Examples:
 


### PR DESCRIPTION
MIB files that use named constants in subtype constraints (e.g. SYNTAX Unsigned32 (WAN7 | WAN8) in ARRIS-D5-SLOT-EXT-MIB) would fail with "Bad grammar near token type UPPERCASE_IDENTIFIER" errors.

This adds a new relaxed grammar option that allows UPPERCASE_IDENTIFIER and LOWERCASE_IDENTIFIER in the value rule used for integer subtype constraints.

> Please note this code was generated by AI, but tested :)