### PR TITLE
fix: add Opaque to constImports for buggy MIBs

### DIFF
--- a/pysmi/codegen/symtable.py
+++ b/pysmi/codegen/symtable.py
@@ -42,6 +42,7 @@ class SymtableCodeGen(AbstractCodeGen):
             "Unsigned32",
             "IpAddress",  # XXX
             "MibIdentifier",
+            "Opaque",  # bug in some MIBs (e.g. JUNIPER-SMI)
         ),  # OBJECT IDENTIFIER
         "SNMPv2-TC": (
             "DisplayString",


### PR DESCRIPTION
MIB files that use Opaque without importing it (e.g. JUNIPER-SMI which uses SYNTAX Opaque in its Integer64 TEXTUAL-CONVENTION) would fail with "Unknown parents for symbols" errors. Adding Opaque to the auto-imported symbols from SNMPv2-SMI fixes this, consistent with how other types like TimeTicks, Counter32, and Gauge32 are already handled.

> Please note this code was generated by AI, but tested :)