### PR TITLE
fix: tolerate lowercase type identifiers in SEQUENCE OF

### DIFF
--- a/pysmi/lexer/smi.py
+++ b/pysmi/lexer/smi.py
@@ -534,6 +534,7 @@ relaxedGrammar = {
     "lowcaseIdentifier": [],
     "curlyBracesAroundEnterpriseInTrap": [],
     "noCells": [],
+    "lowcaseTypeIdentifier": [],
 }
 
 

--- a/pysmi/parser/dialect.py
+++ b/pysmi/parser/dialect.py
@@ -26,6 +26,7 @@ smi_v1_relaxed.update(
     lowcaseIdentifier=True,
     curlyBracesAroundEnterpriseInTrap=True,
     noCells=True,
+    lowcaseTypeIdentifier=True,
 )
 
 # Compatibility API

--- a/pysmi/parser/smi.py
+++ b/pysmi/parser/smi.py
@@ -1420,6 +1420,15 @@ class NoCells:
             p[0] = (p[1], p[3])
 
 
+# noinspection PyIncorrectDocstring
+class LowcaseTypeIdentifier:
+    # common mistake - lowercase type identifier in SEQUENCE OF
+    @staticmethod
+    def p_row(self, p):
+        """row : fuzzy_lowercase_identifier"""
+        p[0] = ('row', p[1])
+
+
 relaxedGrammar = {
     "supportSmiV1Keywords": [
         SupportSmiV1Keywords.p_importedKeyword,
@@ -1438,6 +1447,7 @@ relaxedGrammar = {
         CurlyBracesInEnterprises.p_EnterprisePart,
     ],
     "noCells": [NoCells.p_CreationPart],
+    "lowcaseTypeIdentifier": [LowcaseTypeIdentifier.p_row],
 }
 
 
@@ -1464,6 +1474,7 @@ def parserFactory(**grammarOptions):
         * lowcaseIdentifier - tolerate lowercase MIB identifiers
         * curlyBracesAroundEnterpriseInTrap - tolerate curly braces around enterprise ID in TRAP MACRO
         * noCells - tolerate missing cells (XXX)
+        * lowcaseTypeIdentifier - tolerate lowercase type identifiers in SEQUENCE OF
 
     Examples:
 


### PR DESCRIPTION
Add relaxed grammar option to handle MIB files that incorrectly use lowercase type identifiers in SEQUENCE OF declarations.

> Please note this code was generated by AI, but tested :)
